### PR TITLE
회원가입 및 세션 인증 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,10 @@ dependencies {
     runtimeOnly("com.h2database:h2")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation ("io.kotest:kotest-runner-junit5-jvm:5.9.1")
+    testImplementation ("io.kotest:kotest-assertions-core-jvm:5.9.1")
+    testImplementation ("io.kotest:kotest-property-jvm:5.9.1")
+    testImplementation ("io.kotest.extensions:kotest-extensions-spring:1.3.0")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/src/main/kotlin/com/example/kbocombo/auth/presentation/AuthController.kt
+++ b/src/main/kotlin/com/example/kbocombo/auth/presentation/AuthController.kt
@@ -24,7 +24,6 @@ class AuthController(
     fun getAuthRedirectUri(
         @PathVariable socialProvider: String,
         @RequestParam redirectUri: String,
-        response: HttpServletResponse
     ): ResponseEntity<OAuthRedirectUriResponse> {
         val oAuthRedirectUriResponse = authService.getRedirectUri(
             socialProvider = SocialProvider.valueOf(socialProvider.uppercase(Locale.getDefault())),

--- a/src/main/kotlin/com/example/kbocombo/auth/presentation/AuthController.kt
+++ b/src/main/kotlin/com/example/kbocombo/auth/presentation/AuthController.kt
@@ -5,14 +5,13 @@ import com.example.kbocombo.auth.application.OAuthMemberResponse
 import com.example.kbocombo.auth.application.OAuthRedirectUriResponse
 import com.example.kbocombo.member.domain.vo.SocialProvider
 import jakarta.servlet.http.HttpServletRequest
-import jakarta.servlet.http.HttpServletResponse
+import java.util.Locale
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.util.Locale
 
 
 @RestController

--- a/src/main/kotlin/com/example/kbocombo/config/WebConfig.kt
+++ b/src/main/kotlin/com/example/kbocombo/config/WebConfig.kt
@@ -1,0 +1,18 @@
+package com.example.kbocombo.config
+
+import com.example.kbocombo.member.ui.MemberArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig(
+    private val memberArgumentResolver: MemberArgumentResolver
+) : WebMvcConfigurer {
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(
+            memberArgumentResolver
+        )
+    }
+}

--- a/src/main/kotlin/com/example/kbocombo/config/WebConfig.kt
+++ b/src/main/kotlin/com/example/kbocombo/config/WebConfig.kt
@@ -3,6 +3,7 @@ package com.example.kbocombo.config
 import com.example.kbocombo.member.ui.MemberArgumentResolver
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
@@ -14,5 +15,16 @@ class WebConfig(
         resolvers.add(
             memberArgumentResolver
         )
+    }
+
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+            .allowedOrigins(
+                "https://www.kbo-dev.kro.kr",
+                "https://localhost:5173",
+                "https://localhost:5174"
+            )
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowCredentials(true)
     }
 }

--- a/src/main/kotlin/com/example/kbocombo/member/application/MemberService.kt
+++ b/src/main/kotlin/com/example/kbocombo/member/application/MemberService.kt
@@ -1,0 +1,26 @@
+package com.example.kbocombo.member.application
+
+import com.example.kbocombo.member.domain.Member
+import com.example.kbocombo.member.infra.MemberRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class MemberService(
+    private val memberRepository: MemberRepository
+) {
+
+    @Transactional
+    fun updateNickname(memberId: Long, nickname: String) {
+        val member = memberRepository.findById(memberId)
+
+        val updateMember = Member(
+            id = member.id,
+            email = member.email,
+            socialProvider = member.socialProvider,
+            socialId = member.socialId,
+            nickname = nickname,
+        )
+        memberRepository.save(updateMember)
+    }
+}

--- a/src/main/kotlin/com/example/kbocombo/member/domain/Member.kt
+++ b/src/main/kotlin/com/example/kbocombo/member/domain/Member.kt
@@ -17,7 +17,7 @@ class Member(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
 
-    @Column(name = "email", nullable = false, updatable = false)
+    @Column(name = "email", nullable = false, updatable = false, unique = true)
     val email: String,
 
     @Column(name = "nickname", nullable = false)

--- a/src/main/kotlin/com/example/kbocombo/member/infra/MemberRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/member/infra/MemberRepository.kt
@@ -6,6 +6,6 @@ import org.springframework.data.repository.Repository
 interface MemberRepository : Repository<Member, Long> {
 
     fun save(member: Member): Member
-
     fun findByEmail(email: String): Member?
+    fun findById(id: Long): Member
 }

--- a/src/main/kotlin/com/example/kbocombo/member/infra/MemberRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/member/infra/MemberRepository.kt
@@ -1,0 +1,11 @@
+package com.example.kbocombo.member.infra
+
+import com.example.kbocombo.member.domain.Member
+import org.springframework.data.repository.Repository
+
+interface MemberRepository : Repository<Member, Long> {
+
+    fun save(member: Member): Member
+
+    fun findByEmail(email: String): Member?
+}

--- a/src/main/kotlin/com/example/kbocombo/member/ui/MemberArgumentResolver.kt
+++ b/src/main/kotlin/com/example/kbocombo/member/ui/MemberArgumentResolver.kt
@@ -1,0 +1,45 @@
+package com.example.kbocombo.member.ui
+
+import com.example.kbocombo.member.domain.Member
+import com.example.kbocombo.member.infra.MemberRepository
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.core.MethodParameter
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+import java.lang.IllegalStateException
+
+@Component
+class MemberArgumentResolver(
+    private val memberRepository: MemberRepository
+) : HandlerMethodArgumentResolver {
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.hasParameterAnnotation(MemberResolver::class.java) &&
+                parameter.parameterType == Member::class.java
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): Any? {
+        val request = webRequest.getNativeRequest(HttpServletRequest::class.java)
+            ?: throw IllegalStateException("인증 요청을 처리할 수 없습니다.")
+
+        val session = request.getSession(false)
+            ?: throw IllegalStateException("사용자 인증 정보를 찾을 수 없습니다.")
+
+        val email = session.getAttribute(SESSION_KEY).toString()
+
+        return memberRepository.findByEmail(email)
+            ?: throw IllegalArgumentException("회원 정보를 찾을 수 없습니다. email: $email")
+    }
+
+    companion object {
+        private const val SESSION_KEY = "MEMBER_SESSION_KEY"
+    }
+}

--- a/src/main/kotlin/com/example/kbocombo/member/ui/MemberController.kt
+++ b/src/main/kotlin/com/example/kbocombo/member/ui/MemberController.kt
@@ -1,0 +1,32 @@
+package com.example.kbocombo.member.ui
+
+import com.example.kbocombo.member.application.MemberService
+import com.example.kbocombo.member.domain.Member
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class MemberController(
+    private val memberService: MemberService
+) {
+
+    @PutMapping("/members/nickname")
+    fun changeNickname(
+        @MemberResolver member: Member,
+        @Valid @RequestBody nicknameChangeRequest: NicknameChangeRequest
+    ): ResponseEntity<Unit> {
+        memberService.updateNickname(
+            memberId = member.id,
+            nickname = nicknameChangeRequest.nickname!!
+        )
+        return ResponseEntity.ok().build()
+    }
+}
+
+data class NicknameChangeRequest(
+    @field:NotBlank(message = "닉네임은 빈 값이 될 수 없습니다.") val nickname: String? = null
+)

--- a/src/main/kotlin/com/example/kbocombo/member/ui/MemberResolver.kt
+++ b/src/main/kotlin/com/example/kbocombo/member/ui/MemberResolver.kt
@@ -1,0 +1,5 @@
+package com.example.kbocombo.member.ui
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class MemberResolver()

--- a/src/test/kotlin/com/example/kbocombo/member/application/MemberServiceTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/member/application/MemberServiceTest.kt
@@ -1,0 +1,34 @@
+package com.example.kbocombo.member.application 
+import com.example.kbocombo.member.domain.Member
+import com.example.kbocombo.member.domain.vo.SocialProvider
+import com.example.kbocombo.member.infra.MemberRepository
+import io.kotest.core.spec.style.ExpectSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest(
+    private val memberRepository: MemberRepository,
+    private val memberService: MemberService
+) : ExpectSpec({
+
+    context("회원 정보 변경") {
+        expect("닉네임을 변경한다.") {
+            val member = Member(
+                email = "kbocombo@example.com",
+                nickname = "추강대엽",
+                socialProvider = SocialProvider.KAKAO,
+                socialId = "525245241"
+            )
+            val savedMember = memberRepository.save(member)
+
+            val updateNickname = "이멤버리멤버포에버"
+            memberService.updateNickname(memberId = savedMember.id, nickname = updateNickname)
+
+            val foundMember = memberRepository.findById(savedMember.id)
+            foundMember.nickname shouldBe updateNickname
+        }
+    }
+})


### PR DESCRIPTION
OAuth 로그인 시 회원가입 되어 있지 않은 회원은 회원가입 시키도록 추가했습니다.

이 때 판단을 email 컬럼으로 했어요. `(SocialId, SocialType)` 유니크 컬럼 조건이라서 이 조합으로 조회해도 되는데, email이 좀 더 직관적일 것 같아서 이메일로 했습니다.

인증은 우선 세션으로 인증하도록 구현했습니다아. 
후딱후딱 개발하고 토큰 필요한 시점이 오면 토큰으로 넘어가는게 어떨까요 ㅎㅎ

+ 추가) 닉네임 변경도 여기 같이 붙여서 올릴게요 !