### PR TITLE
실시간 경기 결과 처리 기능

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.querydsl:querydsl-jpa:$querydslVersion:jakarta")
     implementation("com.querydsl:querydsl-sql:$querydslVersion")
-    implementation("com.google.code.gson:gson:2.10.1")
     kapt("com.querydsl:querydsl-apt:$querydslVersion:jakarta")
     kapt("jakarta.persistence:jakarta.persistence-api")
     kapt("jakarta.annotation:jakarta.annotation-api")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     kotlin("jvm") version "1.9.25"
     kotlin("plugin.spring") version "1.9.25"
-    id("org.springframework.boot") version "3.4.1"
+    id("org.springframework.boot") version "3.4.2"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("plugin.jpa") version "1.9.25"
     kotlin("kapt") version "1.9.25"
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.querydsl:querydsl-jpa:$querydslVersion:jakarta")
     implementation("com.querydsl:querydsl-sql:$querydslVersion")
+    implementation("com.google.code.gson:gson:2.10.1")
     kapt("com.querydsl:querydsl-apt:$querydslVersion:jakarta")
     kapt("jakarta.persistence:jakarta.persistence-api")
     kapt("jakarta.annotation:jakarta.annotation-api")

--- a/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
@@ -44,6 +44,6 @@ class ComboService(
     }
 
     private fun findSameDateCombo(memberId: Long, game: Game): Combo? {
-        return comboRepository.findByMemberIdAndGameDate(memberId, game.startDateTime.toLocalDate())
+        return comboRepository.findByMemberIdAndGameDate(memberId, game.startDate)
     }
 }

--- a/src/main/kotlin/com/example/kbocombo/combo/domain/Combo.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/domain/Combo.kt
@@ -50,7 +50,7 @@ class Combo private constructor(
         memberId = memberId,
         game = game,
         playerId = playerId,
-        gameDate = game.startDateTime.toLocalDate()
+        gameDate = game.startDate
     ) {
         checkCreate(game, now)
     }
@@ -64,7 +64,7 @@ class Combo private constructor(
         checkCreate(game, now)
         this.game = game
         this.playerId = playerId
-        this.gameDate = game.startDateTime.toLocalDate()
+        this.gameDate = game.startDate
     }
 
     private fun checkCreate(game: Game, now: LocalDateTime) {
@@ -72,13 +72,15 @@ class Combo private constructor(
             "게임 시작 ${ALLOWED_MINUTES_GAP}분 이전에만 등록할 수 있습니다."
         }
 
-        require(now.toLocalDate() >= game.startDateTime.toLocalDate().minusDays(ALLOWED_DAY_GAP)) {
+        require(now.toLocalDate() >= game.startDate.minusDays(ALLOWED_DAY_GAP)) {
             "게임 시작 ${ALLOWED_DAY_GAP}일 전부터 등록할 수 있습니다."
         }
     }
 
-    private fun isAllowedTimeBefore(game: Game, now: LocalDateTime) =
-        game.startDateTime > now.plusMinutes(ALLOWED_MINUTES_GAP)
+    private fun isAllowedTimeBefore(game: Game, now: LocalDateTime): Boolean {
+        val gameStartDateTime = LocalDateTime.of(game.startDate, game.startTime)
+        return gameStartDateTime > now.plusMinutes(ALLOWED_MINUTES_GAP)
+    }
 
     companion object {
         private const val ALLOWED_MINUTES_GAP = 10L

--- a/src/main/kotlin/com/example/kbocombo/crawler/application/NaverSportClient.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/application/NaverSportClient.kt
@@ -1,0 +1,16 @@
+package com.example.kbocombo.crawler.application
+
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.service.annotation.GetExchange
+import org.springframework.web.service.annotation.HttpExchange
+
+@HttpExchange
+interface NaverSportClient {
+
+    @GetExchange(
+        url = "/schedule/games/{gameCode}/record"
+    )
+    fun getLiveGameRecord(
+        @PathVariable("gameCode") gameCode: String
+    ): String
+}

--- a/src/main/kotlin/com/example/kbocombo/crawler/config/NaverSportClientConfig.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/config/NaverSportClientConfig.kt
@@ -1,0 +1,23 @@
+package com.example.kbocombo.crawler.config
+
+import com.example.kbocombo.crawler.application.NaverSportClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.support.RestClientAdapter
+import org.springframework.web.service.invoker.HttpServiceProxyFactory
+
+@Configuration
+class NaverSportClientConfig {
+
+    @Bean
+    fun naverSportClient() : NaverSportClient {
+        val client = RestClient.builder()
+            .baseUrl("https://api-gw.sports.naver.com")
+            .build()
+        val adapter = RestClientAdapter.create(client)
+        val factory = HttpServiceProxyFactory.builderFor(adapter)
+            .build()
+        return factory.createClient(NaverSportClient::class.java)
+    }
+}

--- a/src/main/kotlin/com/example/kbocombo/crawler/infra/NaverSportHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/infra/NaverSportHandler.kt
@@ -6,7 +6,9 @@ import com.example.kbocombo.crawler.utils.toTeamFilterCode
 import com.example.kbocombo.game.domain.Game
 import com.example.kbocombo.game.infra.GameRepository
 import com.example.kbocombo.player.vo.Team
-import com.google.gson.Gson
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import org.springframework.context.ApplicationEventPublisher
@@ -37,7 +39,10 @@ class NaverSportHandler(
 
     private fun analyzeGameRecord(game: Game, gameCode: String) {
         val gameRecordJsonData = naverSportClient.getLiveGameRecord(gameCode = gameCode)
-        val gameRecord = Gson().fromJson(gameRecordJsonData, NaverSportApiResponse::class.java)
+        val objectMapper = ObjectMapper()
+            .registerKotlinModule()
+            .registerModules(JavaTimeModule())
+        val gameRecord = objectMapper.readValue(gameRecordJsonData, NaverSportApiResponse::class.java)
 
         if (gameRecord.isFailed()) {
             logInfo("${gameCode}에 대한 경기 기록 조회에 실패했습니다.")

--- a/src/main/kotlin/com/example/kbocombo/crawler/infra/NaverSportHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/infra/NaverSportHandler.kt
@@ -1,0 +1,151 @@
+package com.example.kbocombo.crawler.infra
+
+import com.example.kbocombo.common.logInfo
+import com.example.kbocombo.crawler.application.NaverSportClient
+import com.example.kbocombo.crawler.utils.toTeamFilterCode
+import com.example.kbocombo.game.domain.Game
+import com.example.kbocombo.game.infra.GameRepository
+import com.example.kbocombo.player.vo.Team
+import com.google.gson.Gson
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class NaverSportHandler(
+    private val naverSportClient: NaverSportClient,
+    private val gameRepository: GameRepository,
+    private val eventPublisher: ApplicationEventPublisher
+) {
+    /**
+     * -- 오늘 경기에 안타 친 선수 찾기 --
+     * 1. 오늘 진행 중인 경기 가져오기
+     * 2. 해당 경기에서 홈팀, 어웨이팀 코드를 기반으로 게임 코드 생성
+     * 3. 생성한 게임 코드를 기반으로 오늘 경기 기록 조회
+     * 4. 안타를 기록한 선수가 있으면 기록지에 추가. -> 오늘의 안타 이벤트 발행 -> 해당 선수를 투표한 사용자 콤보 달성
+     */
+    fun run(startDate: LocalDate) {
+        val games = gameRepository.findAllByStartDate(startDate)
+        for (game in games) {
+            val homeTeam = game.homeTeam
+            val awayTeam = game.awayTeam
+            val gameCode = generateGameCode(homeTeam, awayTeam, startDate)
+            getGameRecord(game, gameCode)
+        }
+    }
+
+    private fun getGameRecord(game: Game, gameCode: String) {
+        val gameRecordJsonData = naverSportClient.getLiveGameRecord(gameCode = gameCode)
+        val gameRecord = Gson().fromJson(gameRecordJsonData, NaverSportApiResponse::class.java)
+
+        if (gameRecord.isFailed()) {
+            logInfo("${gameCode}에 대한 기록 조회에 실패했습니다.")
+            return
+        }
+
+        if (gameRecord.isGameCanceled()) {
+            logInfo("${gameCode}에 대한 경기는 취소되었습니다.")
+            return
+        }
+        val awayTeamHitters = gameRecord.result.recordData.battersBoxscore.away
+        val homeTeamHitters = gameRecord.result.recordData.battersBoxscore.home
+        awayTeamHitters.forEach { checkIfHitExist(it, game) }
+        homeTeamHitters.forEach { checkIfHitExist(it, game) }
+    }
+
+    /**
+     * 게임 코드 생성 규칙
+     * ex) 2024-06-29, SSG:두산, 잠실야구장 -> 20240629 + SK + OB + 0 + 2024 (정규시즌)
+     * ex) 2024-10-11, KT:LG, 잠실야구장 -> 33331011 + KT + LG + 0  + 2024 (플레이오프) <일단 보류>
+     */
+    private fun generateGameCode(
+        homeTeam: Team,
+        awayTeam: Team,
+        startDate: LocalDate,
+    ): String {
+        val formattedDate = startDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"))
+        val awayTeamCode = toTeamFilterCode(awayTeam)
+        val homeTeamCode = toTeamFilterCode(homeTeam)
+        return "${formattedDate}${awayTeamCode}${homeTeamCode}" + "0" + startDate.year
+    }
+
+    private fun checkIfHitExist(batter: Batter, game: Game) {
+        if (batter.hit > 0) {
+            val playerCode = batter.playerCode
+            eventPublisher.publishEvent(HitterHitRecordedEvent(game.id, playerCode))
+        }
+        return
+    }
+}
+
+data class NaverSportApiResponse(
+    val code: Int,
+    val success: Boolean,
+    val result: Result
+) {
+    fun isFailed(): Boolean = !success
+
+    fun isGameCanceled(): Boolean = result.recordData.battersBoxscore.home.isEmpty()
+            || result.recordData.battersBoxscore.away.isEmpty()
+}
+
+data class Result(
+    val recordData: RecordData
+)
+
+data class RecordData(
+    val battersBoxscore: BattersBoxscore
+)
+
+// 네이버 스포츠에서 Batter 키워드로 사용함. (혼란방지)
+data class BattersBoxscore(
+    val away: List<Batter>,
+    val home: List<Batter>
+)
+
+data class Batter(
+    val bb: Int,
+    val inn9: String,
+    val batOrder: Int,
+    val playerCode: String,
+    val run: Int,
+    val hr: Int,
+    val inn24: String,
+    val inn23: String,
+    val inn22: String,
+    val hit: Int,
+    val inn21: String,
+    val pos: String,
+    val hra: String,
+    val inn25: String,
+    val inn2: String,
+    val inn1: String,
+    val inn4: String,
+    val inn3: String,
+    val inn6: String,
+    val inn20: String,
+    val inn5: String,
+    val inn8: String,
+    val inn7: String,
+    val kk: Int,
+    val ab: Int,
+    val inn19: String,
+    val inn18: String,
+    val hasPlayerEnd: Boolean,
+    val inn13: String,
+    val inn12: String,
+    val inn11: String,
+    val inn10: String,
+    val inn17: String,
+    val inn16: String,
+    val inn15: String,
+    val inn14: String,
+    val name: String,
+    val rbi: Int
+)
+
+data class HitterHitRecordedEvent(
+    val gameId: Long,
+    val playerCode: String
+)

--- a/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
@@ -43,7 +43,11 @@ class Game(
     val gameState: GameState,
 ) : BaseEntity() {
 
-    fun isGameRunning(): Boolean {
+    fun isRunning(): Boolean {
         return gameState == GameState.RUNNING
+    }
+
+    fun isCompleted(): Boolean {
+        return gameState == GameState.COMPLETED
     }
 }

--- a/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
@@ -11,7 +11,8 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
-import java.time.LocalDateTime
+import java.time.LocalDate
+import java.time.LocalTime
 
 @Entity(name = "GAME")
 class Game(
@@ -27,8 +28,11 @@ class Game(
     @Column(name = "away_team", nullable = false)
     val awayTeam: Team,
 
-    @Column(name = "start_datetime", nullable = false)
-    val startDateTime: LocalDateTime,
+    @Column(name = "start_date", nullable = false)
+    val startDate: LocalDate,
+
+    @Column(name = "start_time", nullable = false)
+    val startTime: LocalTime,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "game_type", nullable = false)
@@ -37,4 +41,9 @@ class Game(
     @Enumerated(EnumType.STRING)
     @Column(name = "game_state", nullable = false)
     val gameState: GameState,
-) : BaseEntity()
+) : BaseEntity() {
+
+    fun isGameRunning(): Boolean {
+        return gameState == GameState.RUNNING
+    }
+}

--- a/src/main/kotlin/com/example/kbocombo/game/infra/GameRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/infra/GameRepository.kt
@@ -1,0 +1,10 @@
+package com.example.kbocombo.game.infra
+
+import com.example.kbocombo.game.domain.Game
+import java.time.LocalDate
+import org.springframework.data.repository.Repository
+
+interface GameRepository : Repository<Game, Long> {
+
+    fun findAllByStartDate(startDate: LocalDate) : List<Game>
+}

--- a/src/test/kotlin/com/example/kbocombo/combo/domain/ComboTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/combo/domain/ComboTest.kt
@@ -64,7 +64,8 @@ class ComboTest : StringSpec({
 })
 
 private fun getGame(startDateTime: LocalDateTime) = fixture.giveMeKotlinBuilder<Game>()
-    .setExp(Game::startDateTime, startDateTime)
+    .setExp(Game::startDate, startDateTime.toLocalDate())
+    .setExp(Game::startTime, startDateTime.toLocalTime())
     .sample()
 
 private fun createCombo(

--- a/src/test/kotlin/com/example/kbocombo/combo/infra/FakeGameRepository.kt
+++ b/src/test/kotlin/com/example/kbocombo/combo/infra/FakeGameRepository.kt
@@ -3,10 +3,15 @@ package com.example.kbocombo.combo.infra
 import com.example.kbocombo.game.domain.Game
 import com.example.kbocombo.game.infra.GameRepository
 import com.example.kbocombo.mock.infra.BaseFakeRepository
+import java.time.LocalDate
 
 class FakeGameRepository : BaseFakeRepository<Game>(Game::class), GameRepository {
 
     override fun findById(gameId: Long): Game? {
         return db.find { it.id == gameId }
+    }
+
+    override fun findAllByStartDate(startDate: LocalDate): List<Game> {
+        return db.filter { it.startDate == startDate }
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -6,3 +6,6 @@ spring:
     hibernate:
       format_sql: true
       ddl-auto: create
+
+kakao:
+  client_id: 'grayAndOriKboComboProjectKakaoClientIdValue'


### PR DESCRIPTION
네이버 스포츠 경기 기록을 처리하는 기능입니다.
지난번 회의에서 이야기 했던 gameCode를 바탕으로 경기 결과를 조회할 수 있습니다.

스케줄링 동작은 아직 만들지 않았고, 이번 PR에서는 경기 결과를 처리하는 기능만 집중했습니다!
해당 경기에서 안타를 친 선수가 발생하면, `안타를 침`이라는 이벤트를 발행하고 이벤트 리스너에서 콤보 관련 로직을 추가하는 방향으로 설계했습니다.