### PR TITLE
게임 스케줄러 기능 구현

### DIFF
--- a/src/main/kotlin/com/example/kbocombo/combo/application/ComboHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/application/ComboHandler.kt
@@ -1,7 +1,7 @@
 package com.example.kbocombo.combo.application
 
 import com.example.kbocombo.common.logInfo
-import com.example.kbocombo.crawler.combo.infra.HitterHitRecordedEvent
+import com.example.kbocombo.crawler.game.infra.HitterHitRecordedEvent
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/com/example/kbocombo/crawler/game/application/GameClient.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/game/application/GameClient.kt
@@ -1,9 +1,10 @@
 package com.example.kbocombo.crawler.game.application
 
+import com.example.kbocombo.crawler.game.infra.GameDto
 import com.example.kbocombo.game.domain.Game
 import java.time.LocalDate
 
 interface GameClient {
 
-    fun findGames(gameDate: LocalDate) : List<Game>
+    fun findGames(gameDate: LocalDate) : List<GameDto>
 }

--- a/src/main/kotlin/com/example/kbocombo/crawler/game/application/GameRenewService.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/game/application/GameRenewService.kt
@@ -1,5 +1,7 @@
 package com.example.kbocombo.crawler.game.application
 
+import com.example.kbocombo.crawler.game.infra.GameDto
+import com.example.kbocombo.crawler.game.infra.toEntity
 import com.example.kbocombo.game.domain.Game
 import com.example.kbocombo.game.infra.GameRepository
 import org.springframework.stereotype.Component
@@ -13,13 +15,13 @@ class GameRenewService(
 ) {
 
     @Transactional
-    fun renewGame(games: List<Game>, gameDate: LocalDate, now: LocalDateTime) {
+    fun renewGame(gameDtos: List<GameDto>, gameDate: LocalDate, now: LocalDateTime) {
         val savedGameByCode = gameRepository.findAllByStartDate(gameDate)
             .associateBy { it.gameCode }
-        for (game in games) {
-            val savedGame = savedGameByCode[game.gameCode]
+        for (gameDto in gameDtos) {
+            val savedGame = savedGameByCode[gameDto.gameCode]
             if (savedGame == null) {
-                gameRepository.save(game)
+                gameRepository.save(gameDto.toEntity())
                 continue
             }
 
@@ -29,8 +31,9 @@ class GameRenewService(
 
             updateStartingPitcher(
                 savedGame = savedGame,
-                homeStartingPitcherId = game.homeStartingPitcherId,
-                awayStartingPitcherId = game.awayStartingPitcherId)
+                homeStartingPitcherId = gameDto.homeStartingPitcherId,
+                awayStartingPitcherId = gameDto.awayStartingPitcherId
+            )
         }
     }
 

--- a/src/main/kotlin/com/example/kbocombo/crawler/game/application/GameSyncService.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/game/application/GameSyncService.kt
@@ -11,7 +11,7 @@ class GameSyncService(
 ) {
 
     fun syncGame(gameDate: LocalDate, now: LocalDateTime) {
-        val games = gameClient.findGames(gameDate = gameDate)
-        gameRenewService.renewGame(games = games, gameDate = gameDate, now = now)
+        val gameDtos = gameClient.findGames(gameDate = gameDate)
+        gameRenewService.renewGame(gameDtos = gameDtos, gameDate = gameDate, now = now)
     }
 }

--- a/src/main/kotlin/com/example/kbocombo/crawler/game/infra/NaverSportGameClient.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/game/infra/NaverSportGameClient.kt
@@ -166,3 +166,17 @@ data class GameDto(
     val gameType: GameType,
     val gameState: GameState? = null,
 )
+
+fun GameDto.toEntity(): Game {
+    return Game(
+        gameCode = gameCode,
+        homeTeam = homeTeam,
+        awayTeam = awayTeam,
+        homeStartingPitcherId = homeStartingPitcherId,
+        awayStartingPitcherId = awayStartingPitcherId,
+        gameType = gameType,
+        gameState = gameState ?: GameState.PENDING,
+        startDate = startDate,
+        startTime = startTime,
+    )
+}

--- a/src/main/kotlin/com/example/kbocombo/crawler/game/infra/NaverSportHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/game/infra/NaverSportHandler.kt
@@ -1,10 +1,11 @@
-package com.example.kbocombo.crawler.combo.infra
+package com.example.kbocombo.crawler.game.infra
 
 import com.example.kbocombo.common.logInfo
 import com.example.kbocombo.crawler.common.application.NaverSportClient
 import com.example.kbocombo.crawler.common.utils.toTeamFilterCode
 import com.example.kbocombo.game.domain.Game
 import com.example.kbocombo.game.infra.GameRepository
+import com.example.kbocombo.game.infra.getById
 import com.example.kbocombo.player.vo.Team
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
@@ -27,14 +28,10 @@ class NaverSportHandler(
      * 3. 생성한 게임 코드를 기반으로 오늘 경기 기록 조회
      * 4. 안타를 기록한 선수가 있으면 기록지에 추가. -> 오늘의 안타 이벤트 발행 -> 해당 선수를 투표한 사용자 콤보 달성
      */
-    fun run(startDate: LocalDate) {
-        val games = gameRepository.findAllByStartDate(startDate)
-            .filter { it.isRunning() }
-
-        games.forEach { game ->
-            val gameCode = generateGameCode(game.homeTeam, game.awayTeam, startDate)
-            analyzeGameRecord(game, gameCode)
-        }
+    fun run(gameId: Long) {
+        val game = gameRepository.getById(gameId)
+        val gameCode = generateGameCode(game.homeTeam, game.awayTeam, game.startDate)
+        analyzeGameRecord(game, gameCode)
     }
 
     private fun analyzeGameRecord(game: Game, gameCode: String) {

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
@@ -53,6 +53,12 @@ class GameHandler(
         val gameId = gameRunningEvent.gameId
         logInfo("Game is Running: $gameId")
 
+        val game = gameRepository.getById(gameId)
+        if (game.isRunning().not()) {
+            game.start()
+            gameRepository.save(game)
+        }
+
         naverSportHandler.run(gameId = gameId)
     }
 

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
@@ -22,8 +22,8 @@ class GameHandler(
     @Async
     @EventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    fun handleGameEndedEvent(gameEndedEvent: GameEndedEvent) {
-        val gameId = gameEndedEvent.gameId
+    fun handleGameEndedEvent(gamCompletedEvent: GamCompletedEvent) {
+        val gameId = gamCompletedEvent.gameId
         logInfo("Game ended: $gameId ")
 
         val game = gameRepository.getById(gameId)

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
@@ -31,4 +31,4 @@ class GameHandler(
     }
 }
 
-data class GameEndedEvent(val gameId: Long)
+

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
@@ -1,6 +1,7 @@
 package com.example.kbocombo.game.application
 
 import com.example.kbocombo.common.logInfo
+import com.example.kbocombo.crawler.game.infra.NaverSportHandler
 import com.example.kbocombo.game.domain.GameEndEventJob
 import com.example.kbocombo.game.infra.GameEndEventJobRepository
 import com.example.kbocombo.game.infra.GameRepository
@@ -8,20 +9,65 @@ import com.example.kbocombo.game.infra.getById
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class GameHandler(
     private val gameRepository: GameRepository,
-    private val gameEndEventJobRepository: GameEndEventJobRepository
+    private val gameEndEventJobRepository: GameEndEventJobRepository,
+    private val naverSportHandler: NaverSportHandler
 ) {
 
     @Async
     @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun handleGameEndedEvent(gameEndedEvent: GameEndedEvent) {
         val gameId = gameEndedEvent.gameId
         logInfo("Game ended: $gameId ")
 
         val game = gameRepository.getById(gameId)
+        game.complete()
+        gameRepository.save(game)
+
+        val gameEndEventJob = GameEndEventJob(
+            gameId = gameId,
+            gameDate = game.startDate,
+        )
+
+        gameEndEventJobRepository.save(gameEndEventJob)
+    }
+
+    /**
+     * @author gray
+     * 경기가 진행 중일 때 gameScheduler에서 gameRunningEvnet 발행
+     * 진행 중인 경기에서 안타를 찾도록 -> 콤보 체크
+     */
+    @Async
+    @EventListener
+    fun handleGameRunningEvent(gameRunningEvent: GameRunningEvent) {
+        val gameId = gameRunningEvent.gameId
+        logInfo("Game is Running: $gameId")
+
+        naverSportHandler.run(gameId = gameId)
+    }
+
+    /**
+     * @author gray
+     * 네이버에서 제공하는 CANCEL의 개념이 우천취소, 폭염취소 등과 같은 노게임으로 선언되는 취소인 것 같음.
+     * 그래서 취소가 결정됐을 때, 해당 게임의 콤보를 선택한 사람을 무효화할 수 있도록 GameEndEventJob 저장
+     */
+    @Async
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun handleGameCanceledEvent(gameCanceledEvent: GameCanceledEvent) {
+        val gameId = gameCanceledEvent.gameId
+        logInfo("Game is canceled: $gameId")
+
+        val game = gameRepository.getById(gameId)
+        game.cancel()
+        gameRepository.save(game)
+
         val gameEndEventJob = GameEndEventJob(
             gameId = gameId,
             gameDate = game.startDate,

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
@@ -22,8 +22,8 @@ class GameHandler(
     @Async
     @EventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    fun handleGameEndedEvent(gamCompletedEvent: GamCompletedEvent) {
-        val gameId = gamCompletedEvent.gameId
+    fun handleGameCompletedEvent(gameCompletedEvent: GameCompletedEvent) {
+        val gameId = gameCompletedEvent.gameId
         logInfo("Game ended: $gameId ")
 
         val game = gameRepository.getById(gameId)

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
@@ -36,6 +36,7 @@ class GameHandler(
         )
 
         gameEndEventJobRepository.save(gameEndEventJob)
+        naverSportHandler.run(gameId = game.id)
     }
 
     /**

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
@@ -4,8 +4,6 @@ import com.example.kbocombo.common.logInfo
 import com.example.kbocombo.crawler.game.infra.NaverSportHandler
 import com.example.kbocombo.game.domain.GameEndEventJob
 import com.example.kbocombo.game.infra.GameEndEventJobRepository
-import com.example.kbocombo.game.infra.GameRepository
-import com.example.kbocombo.game.infra.getById
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
@@ -24,9 +24,12 @@ class GameHandler(
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun handleGameCompletedEvent(gameCompletedEvent: GameCompletedEvent) {
         val gameId = gameCompletedEvent.gameId
-        logInfo("Game ended: $gameId ")
-
         val game = gameRepository.getById(gameId)
+        if (game.isCompleted()) {
+            return
+        }
+
+        logInfo("Game ended: $gameId ")
         game.complete()
         gameRepository.save(game)
 
@@ -61,11 +64,14 @@ class GameHandler(
     @Async
     @EventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    fun handleGameCanceledEvent(gameCanceledEvent: GameCanceledEvent) {
-        val gameId = gameCanceledEvent.gameId
-        logInfo("Game is canceled: $gameId")
-
+    fun handleGameCanceledEvent(gameCancelledEvent: GameCancelledEvent) {
+        val gameId = gameCancelledEvent.gameId
         val game = gameRepository.getById(gameId)
+        if (game.isCancelled()) {
+            return
+        }
+
+        logInfo("Game is canceled: $gameId")
         game.cancel()
         gameRepository.save(game)
 

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
@@ -1,6 +1,9 @@
 package com.example.kbocombo.game.application
 
+import com.example.kbocombo.crawler.game.application.GameClient
+import com.example.kbocombo.game.domain.vo.GameState
 import com.example.kbocombo.game.infra.GameEndEventJobRepository
+import org.springframework.context.ApplicationEventPublisher
 import java.time.LocalDateTime
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -9,6 +12,8 @@ import org.springframework.stereotype.Component
 class GameScheduler(
     private val gameEndEventJobRepository: GameEndEventJobRepository,
     private val gameEndEventJobService: GameEndEventJobService,
+    private val gameClient: GameClient,
+    private val publisher: ApplicationEventPublisher
 ) {
 
     @Scheduled(fixedDelay = 600000L)
@@ -23,4 +28,35 @@ class GameScheduler(
 
         processableJobIds.forEach { gameEndEventJobService.process(it!!) }
     }
+
+    @Scheduled(fixedDelay = 600000L)
+    fun scheduleTodayGames() {
+        val now = LocalDateTime.now()
+        val today = now.toLocalDate()
+
+        val todayGames = gameClient.findGames(today)
+
+        for (todayGame in todayGames) {
+            val gameState = todayGame.gameState
+
+            when (gameState) {
+                GameState.RUNNING -> publisher.publishEvent(GameRunningEvent(gameId = todayGame.id))
+                GameState.COMPLETED -> publisher.publishEvent(GameEndedEvent(gameId = todayGame.id))
+                GameState.CANCEL -> publisher.publishEvent(GameCanceledEvent(gameId = todayGame.id))
+                GameState.PENDING -> {}
+            }
+        }
+    }
 }
+
+data class GameRunningEvent(
+    val gameId: Long
+)
+
+data class GameEndedEvent(
+    val gameId: Long
+)
+
+data class GameCanceledEvent(
+    val gameId: Long
+)

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
@@ -41,7 +41,7 @@ class GameScheduler(
 
             when (gameState) {
                 GameState.RUNNING -> publisher.publishEvent(GameRunningEvent(gameId = todayGame.id))
-                GameState.COMPLETED -> publisher.publishEvent(GamCompletedEvent(gameId = todayGame.id))
+                GameState.COMPLETED -> publisher.publishEvent(GameCompletedEvent(gameId = todayGame.id))
                 GameState.CANCEL -> publisher.publishEvent(GameCanceledEvent(gameId = todayGame.id))
                 GameState.PENDING -> {}
             }
@@ -53,7 +53,7 @@ data class GameRunningEvent(
     val gameId: Long
 )
 
-data class GamCompletedEvent(
+data class GameCompletedEvent(
     val gameId: Long
 )
 

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
@@ -5,6 +5,7 @@ import com.example.kbocombo.crawler.game.application.GameClient
 import com.example.kbocombo.game.domain.vo.GameState
 import com.example.kbocombo.game.infra.GameEndEventJobRepository
 import com.example.kbocombo.game.infra.GameRepository
+import java.time.LocalDate
 import org.springframework.context.ApplicationEventPublisher
 import java.time.LocalDateTime
 import org.springframework.scheduling.annotation.Scheduled
@@ -48,8 +49,8 @@ class GameScheduler(
             val currentGameState = todayGameDto.gameState ?: savedTodayGame.gameState
             when (currentGameState) {
                 GameState.RUNNING -> publisher.publishEvent(GameRunningEvent(gameId = savedTodayGame.id))
-                GameState.COMPLETED -> publisher.publishEvent(GameCompletedEvent(gameId = savedTodayGame.id))
-                GameState.CANCEL -> publisher.publishEvent(GameCancelledEvent(gameId = savedTodayGame.id))
+                GameState.COMPLETED -> publisher.publishEvent(GameCompletedEvent(gameId = savedTodayGame.id, gameDate = savedTodayGame.startDate))
+                GameState.CANCEL -> publisher.publishEvent(GameCancelledEvent(gameId = savedTodayGame.id, gameDate = savedTodayGame.startDate))
                 GameState.PENDING -> {}
             }
         }
@@ -61,9 +62,11 @@ data class GameRunningEvent(
 )
 
 data class GameCompletedEvent(
-    val gameId: Long
+    val gameId: Long,
+    val gameDate: LocalDate
 )
 
 data class GameCancelledEvent(
-    val gameId: Long
+    val gameId: Long,
+    val gameDate: LocalDate
 )

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
@@ -41,7 +41,7 @@ class GameScheduler(
 
             when (gameState) {
                 GameState.RUNNING -> publisher.publishEvent(GameRunningEvent(gameId = todayGame.id))
-                GameState.COMPLETED -> publisher.publishEvent(GameEndedEvent(gameId = todayGame.id))
+                GameState.COMPLETED -> publisher.publishEvent(GamCompletedEvent(gameId = todayGame.id))
                 GameState.CANCEL -> publisher.publishEvent(GameCanceledEvent(gameId = todayGame.id))
                 GameState.PENDING -> {}
             }
@@ -53,7 +53,7 @@ data class GameRunningEvent(
     val gameId: Long
 )
 
-data class GameEndedEvent(
+data class GamCompletedEvent(
     val gameId: Long
 )
 

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameService.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameService.kt
@@ -1,0 +1,43 @@
+package com.example.kbocombo.game.application
+
+import com.example.kbocombo.common.logInfo
+import com.example.kbocombo.game.infra.GameRepository
+import com.example.kbocombo.game.infra.getById
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GameService(
+    private val gameRepository: GameRepository,
+) {
+    @Transactional
+    fun run(gameId: Long) {
+        val game = gameRepository.getById(gameId)
+
+        if (game.isRunning().not()) {
+            game.start()
+            gameRepository.save(game)
+        }
+    }
+
+    @Transactional
+    fun complete(gameId: Long) {
+        val game = gameRepository.getById(gameId)
+        if (game.isCompleted()) {
+            throw IllegalStateException("Game is already completed, gameId: $gameId")
+        }
+        game.complete()
+        gameRepository.save(game)
+    }
+
+    @Transactional
+    fun cancel(gameId: Long) {
+        val game = gameRepository.getById(gameId)
+        if (game.isCancelled()) {
+            throw IllegalStateException("Game is canceled, gameId: $gameId")
+        }
+
+        game.cancel()
+        gameRepository.save(game)
+    }
+}

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameService.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameService.kt
@@ -1,6 +1,5 @@
 package com.example.kbocombo.game.application
 
-import com.example.kbocombo.common.logInfo
 import com.example.kbocombo.game.infra.GameRepository
 import com.example.kbocombo.game.infra.getById
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
@@ -76,6 +76,10 @@ class Game(
         return gameState == GameState.COMPLETED
     }
 
+    fun isCancelled(): Boolean {
+        return gameState == GameState.CANCEL
+    }
+
     fun isAfterGameStart(dateTime: LocalDateTime): Boolean {
         return LocalDateTime.of(startDate, startTime) >= dateTime
     }

--- a/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
@@ -32,6 +32,8 @@ class Game(
 
     awayStartingPitcherId: Long?,
 
+    gameState: GameState = GameState.PENDING,
+
     @Enumerated(EnumType.STRING)
     @Column(name = "away_team", nullable = false)
     val awayTeam: Team,
@@ -46,11 +48,11 @@ class Game(
     @Column(name = "game_type", nullable = false)
     val gameType: GameType,
 
-) : BaseEntity() {
+    ) : BaseEntity() {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "game_state", nullable = false)
-    var gameState: GameState = GameState.PENDING
+    var gameState: GameState = gameState
         protected set
 
     @Column(name = "home_starting_pitcher_id")

--- a/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
@@ -36,7 +36,6 @@ class Game(
     @Column(name = "away_team", nullable = false)
     val awayTeam: Team,
 
-
     @Column(name = "start_date", nullable = false)
     val startDate: LocalDate,
 
@@ -47,10 +46,12 @@ class Game(
     @Column(name = "game_type", nullable = false)
     val gameType: GameType,
 
+) : BaseEntity() {
+
     @Enumerated(EnumType.STRING)
     @Column(name = "game_state", nullable = false)
-    val gameState: GameState,
-) : BaseEntity() {
+    var gameState: GameState = GameState.PENDING
+        protected set
 
     @Column(name = "home_starting_pitcher_id")
     var homeStartingPitcherId: Long? = homeStartingPitcherId
@@ -75,5 +76,13 @@ class Game(
 
     fun isAfterGameStart(dateTime: LocalDateTime): Boolean {
         return LocalDateTime.of(startDate, startTime) >= dateTime
+    }
+
+    fun cancel() {
+        this.gameState = GameState.CANCEL
+    }
+
+    fun complete() {
+        this.gameState = GameState.COMPLETED
     }
 }

--- a/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
@@ -91,4 +91,8 @@ class Game(
     fun complete() {
         this.gameState = GameState.COMPLETED
     }
+
+    fun start() {
+        this.gameState = GameState.RUNNING
+    }
 }

--- a/src/main/kotlin/com/example/kbocombo/game/infra/GameRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/infra/GameRepository.kt
@@ -14,4 +14,6 @@ interface GameRepository : Repository<Game, Long> {
     fun findAllByStartDate(startDate: LocalDate) : List<Game>
 
     fun save(game: Game): Game
+
+    fun findByGameCode(gameCode: String): Game?
 }


### PR DESCRIPTION
게임 스케줄러 기능을 구현했습니다.

오늘 치뤄지는 게임을 스케줄러를 통해 게임의 상태를 조회합니다.

조회한 게임의 상태에 따라 이벤트를 발행하여, 각 이벤트를 리스닝하고 있는 쪽에서 적절한 동작을 취하도록 구현했습니다 !

네이버 경기 조회 응답을 쭉 살펴보니 아래와 같은 응답을 확인할 수 있었는데요 !
```json
"statusCode": "BEFORE",
"statusNum": 0,
"statusInfo": "경기전"

"statusCode": "BEFORE",
"statusNum": 0,
"statusInfo": "경기취소",

"statusCode": "STARTED",
"statusNum": 2,
"statusInfo": "후반1'",

"statusCode": "RESULT",
"statusNum": 4,
"statusInfo": "9회말",
```
위 응답에서 statusNum은 여러 의미를 나타내는 것 같아 사용하기 어렵다고 판단했습니다.
그래서 statusCode, statusInfo 문자열을 기반으로 gameStatus를 계산하도록 `convertToGameStatus()` 메서드를 구현했습니다.

또한 이야기했던 대로 해당 경기에서 안타를 쳤는지 확인하는 동작을 `경기 진행 중` 이벤트를 발행하여 동작하도록 구현해봤습니다.
추가적으로 반영해 볼만한 점이나 의견 있으시면 적극 환영입니다 !!!!!!!!!!!!