### PR TITLE
미래 게임 추가 & 선발 투수 업데이트 / 선수 데이터 갱신 스케줄러 추가

### DIFF
--- a/src/main/kotlin/com/example/kbocombo/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/example/kbocombo/config/AsyncConfig.kt
@@ -12,8 +12,8 @@ class AsyncConfig : AsyncConfigurer {
 
     override fun getAsyncExecutor(): Executor {
         val executor = ThreadPoolTaskExecutor()
-        executor.corePoolSize = 1
-        executor.maxPoolSize = 3
+        executor.corePoolSize = 8
+        executor.maxPoolSize = 30
         executor.queueCapacity = 100
         executor.setThreadNamePrefix("async-executor-")
         executor.setWaitForTasksToCompleteOnShutdown(true)

--- a/src/main/kotlin/com/example/kbocombo/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/example/kbocombo/config/AsyncConfig.kt
@@ -1,0 +1,25 @@
+package com.example.kbocombo.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+@Configuration
+@EnableAsync
+class AsyncConfig {
+
+    @Bean
+    fun asyncExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 8
+        executor.maxPoolSize = 20
+        executor.queueCapacity = 100
+        executor.setThreadNamePrefix("async-executor-")
+        executor.setWaitForTasksToCompleteOnShutdown(true)
+        executor.setAwaitTerminationSeconds(30)
+        executor.initialize()
+        return executor
+    }
+}

--- a/src/main/kotlin/com/example/kbocombo/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/example/kbocombo/config/AsyncConfig.kt
@@ -1,20 +1,19 @@
 package com.example.kbocombo.config
 
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.AsyncConfigurer
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.util.concurrent.Executor
 
-@Configuration
 @EnableAsync
-class AsyncConfig {
+@Configuration
+class AsyncConfig : AsyncConfigurer {
 
-    @Bean
-    fun asyncExecutor(): Executor {
+    override fun getAsyncExecutor(): Executor {
         val executor = ThreadPoolTaskExecutor()
-        executor.corePoolSize = 8
-        executor.maxPoolSize = 20
+        executor.corePoolSize = 1
+        executor.maxPoolSize = 3
         executor.queueCapacity = 100
         executor.setThreadNamePrefix("async-executor-")
         executor.setWaitForTasksToCompleteOnShutdown(true)

--- a/src/main/kotlin/com/example/kbocombo/config/SchedulerConfig.kt
+++ b/src/main/kotlin/com/example/kbocombo/config/SchedulerConfig.kt
@@ -1,25 +1,22 @@
 package com.example.kbocombo.config
 
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableScheduling
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
-import java.util.concurrent.Executor
+import org.springframework.scheduling.annotation.SchedulingConfigurer
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+import org.springframework.scheduling.config.ScheduledTaskRegistrar
 
 @Configuration
 @EnableScheduling
-class SchedulerConfig {
+class SchedulerConfig : SchedulingConfigurer {
 
-    @Bean
-    fun schedulerExecutor(): Executor {
-        val executor = ThreadPoolTaskExecutor()
-        executor.corePoolSize = 2
-        executor.maxPoolSize = 5
-        executor.queueCapacity = 100
-        executor.setThreadNamePrefix("scheduler-executor-")
+    override fun configureTasks(taskRegistrar: ScheduledTaskRegistrar) {
+        val executor = ThreadPoolTaskScheduler()
+        executor.poolSize = 2
         executor.setWaitForTasksToCompleteOnShutdown(true)
         executor.setAwaitTerminationSeconds(30)
+        executor.setThreadNamePrefix("scheduled-task-pool-")
         executor.initialize()
-        return executor
+        taskRegistrar.setTaskScheduler(executor)
     }
 }

--- a/src/main/kotlin/com/example/kbocombo/config/SchedulerConfig.kt
+++ b/src/main/kotlin/com/example/kbocombo/config/SchedulerConfig.kt
@@ -1,0 +1,25 @@
+package com.example.kbocombo.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+@Configuration
+@EnableScheduling
+class SchedulerConfig {
+
+    @Bean
+    fun schedulerExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 2
+        executor.maxPoolSize = 5
+        executor.queueCapacity = 100
+        executor.setThreadNamePrefix("scheduler-executor-")
+        executor.setWaitForTasksToCompleteOnShutdown(true)
+        executor.setAwaitTerminationSeconds(30)
+        executor.initialize()
+        return executor
+    }
+}

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
@@ -22,7 +22,7 @@ class GameScheduler(
     private val gameRepository: GameRepository
 ) {
 
-    @Scheduled(fixedDelay = 600000L)
+    @Scheduled(cron = "0 0/10 * * * ?")
     fun scheduleGameEndEventJob() {
         val now = LocalDateTime.now()
         val today = now.toLocalDate()
@@ -35,7 +35,7 @@ class GameScheduler(
         processableJobIds.forEach { gameEndEventJobService.process(it!!) }
     }
 
-    @Scheduled(fixedDelay = 600000L)
+    @Scheduled(cron = "0 0/10 * * * ?")
     fun scheduleTodayGames() {
         val now = LocalDateTime.now()
         val today = now.toLocalDate()
@@ -58,7 +58,7 @@ class GameScheduler(
         }
     }
 
-    @Scheduled(fixedDelay = 1000L * 60L * 60L)
+    @Scheduled(cron = "0 0/30 * * * ?")
     fun schedulePostDateGame() {
         val today = LocalDate.now()
         val now = LocalDateTime.now()

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
@@ -2,20 +2,22 @@ package com.example.kbocombo.game.application
 
 import com.example.kbocombo.common.logInfo
 import com.example.kbocombo.crawler.game.application.GameClient
+import com.example.kbocombo.crawler.game.application.GameSyncService
 import com.example.kbocombo.game.domain.vo.GameState
 import com.example.kbocombo.game.infra.GameEndEventJobRepository
 import com.example.kbocombo.game.infra.GameRepository
-import java.time.LocalDate
 import org.springframework.context.ApplicationEventPublisher
-import java.time.LocalDateTime
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Component
 class GameScheduler(
     private val gameEndEventJobRepository: GameEndEventJobRepository,
     private val gameEndEventJobService: GameEndEventJobService,
     private val gameClient: GameClient,
+    private val gameSyncService: GameSyncService,
     private val publisher: ApplicationEventPublisher,
     private val gameRepository: GameRepository
 ) {
@@ -53,6 +55,17 @@ class GameScheduler(
                 GameState.CANCEL -> publisher.publishEvent(GameCancelledEvent(gameId = savedTodayGame.id, gameDate = savedTodayGame.startDate))
                 GameState.PENDING -> {}
             }
+        }
+    }
+
+    @Scheduled(fixedDelay = 1000L * 60L * 60L)
+    fun schedulePostDateGame() {
+        val today = LocalDate.now()
+        val now = LocalDateTime.now()
+        for (i in 0..6) {
+            val targetDate = today.plusDays(i.toLong())
+            gameSyncService.syncGame(targetDate, now)
+            logInfo("renew post date game, game date is $targetDate")
         }
     }
 }

--- a/src/main/kotlin/com/example/kbocombo/player/application/PlayerScheduler.kt
+++ b/src/main/kotlin/com/example/kbocombo/player/application/PlayerScheduler.kt
@@ -1,0 +1,18 @@
+package com.example.kbocombo.player.application
+
+import com.example.kbocombo.common.logInfo
+import com.example.kbocombo.crawler.player.application.PlayerSyncService
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class PlayerScheduler(
+    private val playerSyncService: PlayerSyncService
+) {
+
+    @Scheduled(cron = "0 0 5 * * ?")
+    fun schedulePlayerData() {
+        playerSyncService.syncAllPlayerData()
+        logInfo("sync player data")
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
+server:
+  shutdown: graceful
 spring:
   profiles:
     active: local


### PR DESCRIPTION
```schedulePlayerData```는 매일 새벽 5시에 1번 선수 데이터 갱신합니다.
``schedulePostDateGame``는 1시간 간격으로 오늘 ~ 미래 N일 게임이 Db에 없으면 추가, 선발 투수가 변경되거나 추가됐다면 업데이트합니다.
