### PR TITLE
서버 로깅 프레임워크 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.querydsl:querydsl-jpa:$querydslVersion:jakarta")
     implementation("com.querydsl:querydsl-sql:$querydslVersion")
+    implementation("com.github.maricn:logback-slack-appender:1.6.1")
     kapt("com.querydsl:querydsl-apt:$querydslVersion:jakarta")
     kapt("jakarta.persistence:jakarta.persistence-api")
     kapt("jakarta.annotation:jakarta.annotation-api")

--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/file-error-appender.xml
+++ b/src/main/resources/file-error-appender.xml
@@ -1,0 +1,18 @@
+<included>
+    <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./log/haruhanta-prod-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>50</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/src/main/resources/file-info-appender.xml
+++ b/src/main/resources/file-info-appender.xml
@@ -1,0 +1,13 @@
+<included>
+    <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./log/haruhanta-dev-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>50</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %clr(%5level) %cyan(%logger) - %msg%n"/>
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger - %msg%n"/>
+
+    <!--local-->
+    <include resource="console-appender.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+    <!--dev-->
+    <springProfile name="dev">
+        <include resource="file-info-appender.xml"/>
+        <include resource="slack-notification-dev-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="FILE-INFO"/>
+            <appender-ref ref="ASYNC_SLACK"/>
+        </root>
+
+        <logger level="DEBUG" name="org.hibernate.SQL">
+            <appender-ref ref="FILE-INFO"/>
+        </logger>
+
+        <logger level="TRACE" name="org.hibernate.type.descriptor.sql.BasicBinder">
+            <appender-ref ref="FILE-INFO"/>
+        </logger>
+    </springProfile>
+
+    <!--prd-->
+    <springProfile name="prd">
+        <include resource="file-info-appender.xml"/>
+        <include resource="slack-notification-prd-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="FILE-INFO"/>
+            <appender-ref ref="ASYNC_SLACK"/>
+        </root>
+
+        <logger level="DEBUG" name="org.hibernate.SQL">
+            <appender-ref ref="FILE-INFO"/>
+        </logger>
+
+        <logger level="TRACE" name="org.hibernate.type.descriptor.sql.BasicBinder">
+            <appender-ref ref="FILE-INFO"/>
+        </logger>
+    </springProfile>
+
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -21,7 +21,6 @@
 
         <root level="INFO">
             <appender-ref ref="FILE-INFO"/>
-            <appender-ref ref="ASYNC_SLACK"/>
         </root>
 
         <logger level="DEBUG" name="org.hibernate.SQL">
@@ -31,6 +30,11 @@
         <logger level="TRACE" name="org.hibernate.type.descriptor.sql.BasicBinder">
             <appender-ref ref="FILE-INFO"/>
         </logger>
+
+        <logger level="ERROR" name="com.example">
+            <appender-ref ref="ASYNC_SLACK"/>
+        </logger>
+
     </springProfile>
 
     <!--prd-->
@@ -49,6 +53,10 @@
 
         <logger level="TRACE" name="org.hibernate.type.descriptor.sql.BasicBinder">
             <appender-ref ref="FILE-INFO"/>
+        </logger>
+
+        <logger level="ERROR" name="com.example">
+            <appender-ref ref="ASYNC_SLACK"/>
         </logger>
     </springProfile>
 

--- a/src/main/resources/slack-notification-dev-appender.xml
+++ b/src/main/resources/slack-notification-dev-appender.xml
@@ -1,0 +1,16 @@
+<included>
+    <springProperty scope="context" name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-url"/>
+    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </layout>
+        <username>하루한타-개발-서버-로그</username>
+<!--        <iconEmoji>:야구:</iconEmoji>-->
+        <colorCoding>true</colorCoding>
+    </appender>
+
+    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK"/>
+    </appender>
+</included>

--- a/src/main/resources/slack-notification-prd-appender.xml
+++ b/src/main/resources/slack-notification-prd-appender.xml
@@ -1,0 +1,16 @@
+<included>
+    <springProperty scope="context" name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-url"/>
+    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </layout>
+        <username>하루한타-운영-서버-로그</username>
+<!--        <iconEmoji>:야구:</iconEmoji>-->
+        <colorCoding>true</colorCoding>
+    </appender>
+
+    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK"/>
+    </appender>
+</included>


### PR DESCRIPTION
Logback을 활용해서 로깅 프레임워크를 추가했습니다.

기본적으로 생성되는 로그들은 파일로 저장되게끔 구현했습니다.

플러스 dev, prd 환경에 따라서 로그 파일을 분리했고, 에러 레벨의 로그가 발생하는 경우 슬랙에 노티가 가도록 설정했습니다 !