### PR TITLE
이미 GameEndEventJob이 존재하는 경우 return 하도록 변경

### DIFF
--- a/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
@@ -27,6 +27,10 @@ class GameHandler(
 
         gameService.complete(gameId)
 
+        gameEndEventJobRepository.findByGameId(gameId)?.let {
+            return
+        }
+
         val gameEndEventJob = GameEndEventJob(
             gameId = gameId,
             gameDate = gameDate,
@@ -65,6 +69,10 @@ class GameHandler(
 
         gameService.cancel(gameId)
         logInfo("Game is canceled: $gameId")
+
+        gameEndEventJobRepository.findByGameId(gameId)?.let {
+            return
+        }
 
         val gameEndEventJob = GameEndEventJob(
             gameId = gameId,

--- a/src/main/kotlin/com/example/kbocombo/game/infra/GameEndEventJobRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/infra/GameEndEventJobRepository.kt
@@ -2,6 +2,7 @@ package com.example.kbocombo.game.infra
 
 import com.example.kbocombo.game.domain.GameEndEventJob
 import org.springframework.data.repository.Repository
+import java.time.LocalDate
 
 interface GameEndEventJobRepository : Repository<GameEndEventJob, Long> {
 
@@ -10,4 +11,6 @@ interface GameEndEventJobRepository : Repository<GameEndEventJob, Long> {
     fun findAllByProcessed(processed: Boolean): List<GameEndEventJob>
 
     fun findById(id: Long): GameEndEventJob
+
+    fun findByGameId(gameId: Long): GameEndEventJob?
 }


### PR DESCRIPTION
기존에 게임 종료, 게임 취소가 발생했을 때 throw하던 동작을 return 하도록 변경하면서, 이후 흐름의 로직이 실행되었습니다.

그래서 GameEndEventJob이 중복으로 생성되는 문제가 발생했습니다.

이미 존재하는 경우 early return 하도록 추가했습니다.