### PR TITLE
Player 크롤러에서 Parse 실패시 log.warn으로 변경

### DIFF
--- a/src/main/kotlin/com/example/kbocombo/crawler/player/infra/KboPlayerDetailPageParser.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/player/infra/KboPlayerDetailPageParser.kt
@@ -1,6 +1,6 @@
 package com.example.kbocombo.crawler.player.infra
 
-import com.example.kbocombo.common.logError
+import com.example.kbocombo.common.logWarn
 import com.example.kbocombo.crawler.common.utils.toHittingHand
 import com.example.kbocombo.crawler.common.utils.toPitchingHand
 import com.example.kbocombo.crawler.common.utils.toPlayerDetailPosition
@@ -24,7 +24,7 @@ class KboPlayerDetailPageParser {
 
     fun getPlayerProfile(playerData: WebPlayerInfo): Player? {
         return runCatching { toPlayer(playerData) }
-            .onFailure { e -> logError("Failed to parse player with ${playerData.webId}", e) }
+            .onFailure { e -> logWarn("Failed to parse player with ${playerData.webId}", e) }
             .getOrNull()
     }
 


### PR DESCRIPTION
현재 기준으로

https://www.koreabaseball.com/Record/Player/HitterDetail/Basic.aspx?playerId=96153
(키 / 몸무게가 없음)

https://www.koreabaseball.com/Record/Player/HitterDetail/Basic.aspx?playerId=64202
(드래프트 정보가 없음)

에서 실패하는데 둘다 현역 선수인지도 모르겠고... 70몇년생은 코치나 다른 데이터가 잘못들어간기도 하고요.
그래서 해당 케이스를 저장 가능하게 하기보다 log.warn으로만 변경하겠습니다.