### PR TITLE
게임 데이터 갱신하는 스케줄러에서 시작시간도 갱신 하도록 수정

### DIFF
--- a/src/main/kotlin/com/example/kbocombo/crawler/game/application/GameRenewService.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/game/application/GameRenewService.kt
@@ -34,7 +34,7 @@ class GameRenewService(
     }
 
     private fun updateGameData(savedGame: Game, gameDto: GameDto) {
-        savedGame.updateStartingPitcher(
+        savedGame.updateGameData(
             gameStartTime = gameDto.startTime,
             homeStartingPitcherId = gameDto.homeStartingPitcherId,
             awayStartingPitcherId = gameDto.awayStartingPitcherId,

--- a/src/main/kotlin/com/example/kbocombo/crawler/game/application/GameRenewService.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/game/application/GameRenewService.kt
@@ -29,18 +29,15 @@ class GameRenewService(
                 continue
             }
 
-            updateStartingPitcher(
-                savedGame = savedGame,
-                homeStartingPitcherId = gameDto.homeStartingPitcherId,
-                awayStartingPitcherId = gameDto.awayStartingPitcherId
-            )
+            updateGameData(savedGame = savedGame, gameDto = gameDto)
         }
     }
 
-    private fun updateStartingPitcher(savedGame: Game, homeStartingPitcherId: Long?, awayStartingPitcherId: Long?) {
+    private fun updateGameData(savedGame: Game, gameDto: GameDto) {
         savedGame.updateStartingPitcher(
-            homeStartingPitcherId = homeStartingPitcherId,
-            awayStartingPitcherId = awayStartingPitcherId,
+            gameStartTime = gameDto.startTime,
+            homeStartingPitcherId = gameDto.homeStartingPitcherId,
+            awayStartingPitcherId = gameDto.awayStartingPitcherId,
         )
     }
 }

--- a/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
@@ -66,7 +66,7 @@ class Game(
     var startTime: LocalTime = startTime
         protected set
 
-    fun updateStartingPitcher(gameStartTime: LocalTime, homeStartingPitcherId: Long?, awayStartingPitcherId: Long?) {
+    fun updateGameData(gameStartTime: LocalTime, homeStartingPitcherId: Long?, awayStartingPitcherId: Long?) {
         this.homeStartingPitcherId = homeStartingPitcherId
         this.awayStartingPitcherId = awayStartingPitcherId
         this.startTime = gameStartTime

--- a/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
@@ -41,8 +41,7 @@ class Game(
     @Column(name = "start_date", nullable = false)
     val startDate: LocalDate,
 
-    @Column(name = "start_time", nullable = false)
-    val startTime: LocalTime,
+    startTime: LocalTime,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "game_type", nullable = false)
@@ -63,9 +62,14 @@ class Game(
     var awayStartingPitcherId: Long? = awayStartingPitcherId
         protected set
 
-    fun updateStartingPitcher(homeStartingPitcherId: Long?, awayStartingPitcherId: Long?) {
+    @Column(name = "start_time", nullable = false)
+    var startTime: LocalTime = startTime
+        protected set
+
+    fun updateStartingPitcher(gameStartTime: LocalTime, homeStartingPitcherId: Long?, awayStartingPitcherId: Long?) {
         this.homeStartingPitcherId = homeStartingPitcherId
         this.awayStartingPitcherId = awayStartingPitcherId
+        this.startTime = gameStartTime
     }
 
     fun isRunning(): Boolean {


### PR DESCRIPTION
어제 보니까 13시던 NC 게임이 18:30으로 변경됐습니다.

아마 정규시즌 개막하고도 간헐적으로 이런 일이 발생할 것 같아요. 공중파 중계가 잡혀서 주말 저녁게임이 13시로 변경된다던가
그래서 선발투수를 업데이트하면서 게임 시간도 갱신하도록 수정했습니다.

