### PR TITLE
타자의 게임별 타수 / 안타 기록을 저장한다.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,6 @@ dependencies {
     testImplementation ("io.kotest:kotest-runner-junit5-jvm:$kotestVersion")
     testImplementation ("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
     testImplementation ("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
-    implementation ("io.kotest:kotest-framework-datatest:$kotestVersion")
     testImplementation ("io.kotest.extensions:kotest-extensions-spring:1.3.0")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ repositories {
 val fixtureMonkeyVersion = "1.1.8"
 
 val jsoupVersion = "1.17.2"
+val kotestVersion = "5.9.1"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
@@ -47,13 +48,15 @@ dependencies {
 
     testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter-kotlin:$fixtureMonkeyVersion")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation ("io.kotest:kotest-runner-junit5-jvm:5.9.1")
-    testImplementation ("io.kotest:kotest-assertions-core-jvm:5.9.1")
-    testImplementation ("io.kotest:kotest-property-jvm:5.9.1")
+    testImplementation ("io.kotest:kotest-runner-junit5-jvm:$kotestVersion")
+    testImplementation ("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
+    testImplementation ("io.kotest:kotest-property-jvm:$kotestVersion")
+    testImplementation ("io.kotest:kotest-runner-junit5-jvm:$kotestVersion")
+    testImplementation ("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
+    testImplementation ("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
+    implementation ("io.kotest:kotest-framework-datatest:$kotestVersion")
     testImplementation ("io.kotest.extensions:kotest-extensions-spring:1.3.0")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-    testImplementation ("io.kotest:kotest-runner-junit5-jvm:5.9.1")
-    testImplementation ("io.kotest:kotest-assertions-core-jvm:5.9.1")
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/src/main/kotlin/com/example/kbocombo/combo/application/ComboHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/application/ComboHandler.kt
@@ -1,10 +1,13 @@
 package com.example.kbocombo.combo.application
 
 import com.example.kbocombo.common.logInfo
-import com.example.kbocombo.crawler.game.infra.HitterHitRecordedEvent
-import org.springframework.context.event.EventListener
+import com.example.kbocombo.record.domain.HitterHitRecordedEvent
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation.REQUIRES_NEW
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
 
 @Component
 class ComboHandler(
@@ -12,12 +15,13 @@ class ComboHandler(
 ) {
 
     @Async
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = REQUIRES_NEW)
     fun handleHitterHitRecordedEvent(hitterHitRecordedEvent: HitterHitRecordedEvent) {
         val gameId = hitterHitRecordedEvent.gameId
-        val playerCode = hitterHitRecordedEvent.playerCode
-        logInfo("Player code: $playerCode hits in game: $gameId ")
+        val playerId = hitterHitRecordedEvent.playerId
+        logInfo("Player Id: $playerId hits in game: $gameId ")
 
-        comboService.updateComboToSuccess(gameId = gameId, playerWebId = playerCode.toLong())
+        comboService.updateComboToSuccess(gameId = gameId, playerId = playerId)
     }
 }

--- a/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
@@ -11,9 +11,6 @@ import com.example.kbocombo.game.infra.GameRepository
 import com.example.kbocombo.game.infra.getById
 import com.example.kbocombo.player.infra.PlayerRepository
 import com.example.kbocombo.player.infra.getById
-import com.example.kbocombo.player.infra.getByWebId
-import com.example.kbocombo.player.vo.WebId
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -23,7 +20,6 @@ class ComboService(
     private val gameRepository: GameRepository,
     private val playerRepository: PlayerRepository,
     private val comboRepository: ComboRepository,
-    private val publisher: ApplicationEventPublisher
 ) {
 
     @Transactional
@@ -50,13 +46,13 @@ class ComboService(
     }
 
     @Transactional
-    fun updateComboToSuccess(gameId: Long, playerWebId: Long) {
-        val game = gameRepository.getById(gameId)
+    fun updateComboToSuccess(gameId: Long, playerId: Long) {
+        val game = gameRepository.getById(gameId = gameId)
         if (game.isRunning().not()) {
             logInfo("진행 중인 게임이 아닌 경우, 콤보 성공 처리를 할 수 없습니다.")
             return
         }
-        val player = playerRepository.getByWebId(webId = WebId(playerWebId))
+        val player = playerRepository.getById(playerId = playerId)
         val combos = comboRepository.findAllByGameAndPlayerIdAndComboStatus(
             game = game,
             playerId = player.id,

--- a/src/main/kotlin/com/example/kbocombo/combo/infra/ComboQueryRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/infra/ComboQueryRepository.kt
@@ -4,8 +4,8 @@ import com.example.kbocombo.combo.domain.Combo
 import com.example.kbocombo.combo.domain.QCombo.combo
 import com.example.kbocombo.game.domain.QGame.game
 import com.example.kbocombo.game.domain.vo.GameType
-import com.example.kbocombo.player.QPlayer.player
 import com.example.kbocombo.player.domain.Player
+import com.example.kbocombo.player.domain.QPlayer.player
 import com.example.kbocombo.utils.before
 import com.example.kbocombo.utils.eq
 import com.querydsl.core.BooleanBuilder

--- a/src/main/kotlin/com/example/kbocombo/combo/infra/ComboQueryRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/infra/ComboQueryRepository.kt
@@ -4,8 +4,8 @@ import com.example.kbocombo.combo.domain.Combo
 import com.example.kbocombo.combo.domain.QCombo.combo
 import com.example.kbocombo.game.domain.QGame.game
 import com.example.kbocombo.game.domain.vo.GameType
-import com.example.kbocombo.player.Player
 import com.example.kbocombo.player.QPlayer.player
+import com.example.kbocombo.player.domain.Player
 import com.example.kbocombo.utils.before
 import com.example.kbocombo.utils.eq
 import com.querydsl.core.BooleanBuilder

--- a/src/main/kotlin/com/example/kbocombo/common/AggrgateBaseEntity.kt
+++ b/src/main/kotlin/com/example/kbocombo/common/AggrgateBaseEntity.kt
@@ -1,17 +1,23 @@
 package com.example.kbocombo.common
 
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.domain.AbstractAggregateRoot
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
 
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
 abstract class AggregateBaseEntity<T : AggregateBaseEntity<T>> : AbstractAggregateRoot<T>() {
 
     @CreatedDate
-    val createdDateTime: LocalDateTime = LocalDateTime.now()
-
+    @Column(updatable = false)
+    var createdDateTime: LocalDateTime = LocalDateTime.now()
+        protected set
     @LastModifiedDate
-    val updatedDateTime: LocalDateTime = LocalDateTime.now()
+    var updatedDateTime: LocalDateTime = LocalDateTime.now()
+        protected set
 }

--- a/src/main/kotlin/com/example/kbocombo/common/AggrgateBaseEntity.kt
+++ b/src/main/kotlin/com/example/kbocombo/common/AggrgateBaseEntity.kt
@@ -1,0 +1,17 @@
+package com.example.kbocombo.common
+
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.domain.AbstractAggregateRoot
+import java.time.LocalDateTime
+
+@MappedSuperclass
+abstract class AggregateBaseEntity<T : AggregateBaseEntity<T>> : AbstractAggregateRoot<T>() {
+
+    @CreatedDate
+    val createdDateTime: LocalDateTime = LocalDateTime.now()
+
+    @LastModifiedDate
+    val updatedDateTime: LocalDateTime = LocalDateTime.now()
+}

--- a/src/main/kotlin/com/example/kbocombo/common/Log.kt
+++ b/src/main/kotlin/com/example/kbocombo/common/Log.kt
@@ -16,4 +16,8 @@ fun Any.logWarn(message: String? = null, e: Throwable) {
     logger().warn(message ?: e.message ?: e.localizedMessage, e)
 }
 
+fun Any.logWarn(message: String) {
+    logger().warn(message)
+}
+
 private fun Any.logger(): Logger = LoggerFactory.getLogger(this.javaClass)

--- a/src/main/kotlin/com/example/kbocombo/crawler/game/application/HitterRecordClient.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/game/application/HitterRecordClient.kt
@@ -1,6 +1,7 @@
 package com.example.kbocombo.crawler.game.application
 
-import com.example.kbocombo.record.application.HitterRecordDto
+import com.example.kbocombo.crawler.game.infra.dto.HitterRecordDto
+
 
 interface HitterRecordClient {
 

--- a/src/main/kotlin/com/example/kbocombo/crawler/game/application/HitterRecordClient.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/game/application/HitterRecordClient.kt
@@ -1,0 +1,8 @@
+package com.example.kbocombo.crawler.game.application
+
+import com.example.kbocombo.record.application.HitterRecordDto
+
+interface HitterRecordClient {
+
+    fun findAll(gameId: Long): List<HitterRecordDto>
+}

--- a/src/main/kotlin/com/example/kbocombo/crawler/game/infra/NaverSportHitterRecordClient.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/game/infra/NaverSportHitterRecordClient.kt
@@ -5,11 +5,11 @@ import com.example.kbocombo.common.logWarn
 import com.example.kbocombo.crawler.common.application.NaverSportClient
 import com.example.kbocombo.crawler.common.utils.toTeamFilterCode
 import com.example.kbocombo.crawler.game.application.HitterRecordClient
+import com.example.kbocombo.crawler.game.infra.dto.HitterRecordDto
 import com.example.kbocombo.game.infra.GameRepository
 import com.example.kbocombo.game.infra.getById
 import com.example.kbocombo.player.vo.Team
 import com.example.kbocombo.player.vo.WebId
-import com.example.kbocombo.record.application.HitterRecordDto
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
 import java.time.LocalDate

--- a/src/main/kotlin/com/example/kbocombo/crawler/game/infra/NaverSportHitterRecordClient.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/game/infra/NaverSportHitterRecordClient.kt
@@ -1,6 +1,7 @@
 package com.example.kbocombo.crawler.game.infra
 
 import com.example.kbocombo.common.logInfo
+import com.example.kbocombo.common.logWarn
 import com.example.kbocombo.crawler.common.application.NaverSportClient
 import com.example.kbocombo.crawler.common.utils.toTeamFilterCode
 import com.example.kbocombo.crawler.game.application.HitterRecordClient
@@ -39,7 +40,7 @@ class NaverSportHitterRecordClient(
         val gameRecord = objectMapper.readValue(gameRecordJsonData, NaverSportApiResponse::class.java)
 
         if (gameRecord.isFailed()) {
-            logInfo("${gameCode}에 대한 경기 기록 조회에 실패했습니다.")
+            logWarn("${gameCode}에 대한 경기 기록 조회에 실패했습니다.")
             return emptyList()
         }
 

--- a/src/main/kotlin/com/example/kbocombo/crawler/game/infra/NaverSportHitterRecordClient.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/game/infra/NaverSportHitterRecordClient.kt
@@ -139,10 +139,4 @@ data class Batter(
     val inn14: String,
     val name: String,
     val rbi: Int
-) {
-}
-
-data class HitterHitRecordedEvent(
-    val gameId: Long,
-    val playerCode: String
 )

--- a/src/main/kotlin/com/example/kbocombo/crawler/game/infra/NaverSportHitterRecordClient.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/game/infra/NaverSportHitterRecordClient.kt
@@ -50,9 +50,9 @@ class NaverSportHitterRecordClient(
         return gameRecord.result.recordData.battersBoxscore.let { boxscore ->
             (boxscore.away + boxscore.home).map {
                 HitterRecordDto(
-                    webId = WebId( it.playerCode),
-                    pa = it.ab,
-                    hit = it.hit
+                    webId = WebId(it.playerCode),
+                    atBats = it.ab,
+                    hits = it.hit
                 )
             }
         }

--- a/src/main/kotlin/com/example/kbocombo/crawler/game/infra/NaverSportHitterRecordClient.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/game/infra/NaverSportHitterRecordClient.kt
@@ -27,7 +27,6 @@ class NaverSportHitterRecordClient(
      * 1. 오늘 진행 중인 경기 가져오기
      * 2. 해당 경기에서 홈팀, 어웨이팀 코드를 기반으로 게임 코드 생성
      * 3. 생성한 게임 코드를 기반으로 오늘 경기 기록 조회
-     * 4. 안타를 기록한 선수가 있으면 기록지에 추가. -> 오늘의 안타 이벤트 발행 -> 해당 선수를 투표한 사용자 콤보 달성
      */
     override fun findAll(gameId: Long): List<HitterRecordDto> {
         val game = gameRepository.getById(gameId)

--- a/src/main/kotlin/com/example/kbocombo/crawler/game/infra/dto/Dto.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/game/infra/dto/Dto.kt
@@ -1,0 +1,9 @@
+package com.example.kbocombo.crawler.game.infra.dto
+
+import com.example.kbocombo.player.vo.WebId
+
+data class HitterRecordDto(
+    val webId: WebId,
+    val atBats: Int,
+    val hits: Int
+)

--- a/src/main/kotlin/com/example/kbocombo/crawler/player/application/PlayerClient.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/player/application/PlayerClient.kt
@@ -1,6 +1,6 @@
 package com.example.kbocombo.crawler.player.application
 
-import com.example.kbocombo.player.Player
+import com.example.kbocombo.player.domain.Player
 
 interface PlayerClient {
 

--- a/src/main/kotlin/com/example/kbocombo/crawler/player/application/PlayerRenewService.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/player/application/PlayerRenewService.kt
@@ -1,6 +1,6 @@
 package com.example.kbocombo.crawler.player.application
 
-import com.example.kbocombo.player.Player
+import com.example.kbocombo.player.domain.Player
 import com.example.kbocombo.player.infra.PlayerRepository
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/com/example/kbocombo/crawler/player/infra/KboPlayerCrawler.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/player/infra/KboPlayerCrawler.kt
@@ -1,7 +1,7 @@
 package com.example.kbocombo.crawler.player.infra
 
 import com.example.kbocombo.crawler.player.application.PlayerClient
-import com.example.kbocombo.player.Player
+import com.example.kbocombo.player.domain.Player
 import org.springframework.stereotype.Component
 
 @Component

--- a/src/main/kotlin/com/example/kbocombo/crawler/player/infra/KboPlayerDetailPageParser.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/player/infra/KboPlayerDetailPageParser.kt
@@ -4,7 +4,7 @@ import com.example.kbocombo.common.logWarn
 import com.example.kbocombo.crawler.common.utils.toHittingHand
 import com.example.kbocombo.crawler.common.utils.toPitchingHand
 import com.example.kbocombo.crawler.common.utils.toPlayerDetailPosition
-import com.example.kbocombo.player.Player
+import com.example.kbocombo.player.domain.Player
 import com.example.kbocombo.player.vo.HittingHandType
 import com.example.kbocombo.player.vo.PitchingHandType
 import com.example.kbocombo.player.vo.PlayerDetailPosition

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
@@ -6,6 +6,7 @@ import com.example.kbocombo.game.domain.vo.GameState
 import com.example.kbocombo.game.infra.GameEndEventJobRepository
 import com.example.kbocombo.game.infra.GameRepository
 import com.example.kbocombo.game.infra.getById
+import com.example.kbocombo.record.application.HitterGameRecordService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -14,6 +15,7 @@ import java.time.LocalDateTime
 class GameEndEventJobService(
     private val gameRepository: GameRepository,
     private val gameEndEventJobRepository: GameEndEventJobRepository,
+    private val hitterGameRecordService: HitterGameRecordService,
     private val comboService: ComboService,
     private val comboRankService: ComboRankService
 ) {
@@ -36,5 +38,6 @@ class GameEndEventJobService(
 
         gameEndEventJob.finish()
         gameEndEventJobRepository.save(gameEndEventJob)
+        hitterGameRecordService.deleteAllHitterRecordIfGameCanceled(game)
     }
 }

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
@@ -1,9 +1,10 @@
 package com.example.kbocombo.game.application
 
 import com.example.kbocombo.common.logInfo
-import com.example.kbocombo.crawler.game.infra.NaverSportHandler
+import com.example.kbocombo.crawler.game.application.HitterRecordClient
 import com.example.kbocombo.game.domain.GameEndEventJob
 import com.example.kbocombo.game.infra.GameEndEventJobRepository
+import com.example.kbocombo.record.application.HitterGameRecordService
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
@@ -14,7 +15,8 @@ import org.springframework.transaction.annotation.Transactional
 class GameHandler(
     private val gameService: GameService,
     private val gameEndEventJobRepository: GameEndEventJobRepository,
-    private val naverSportHandler: NaverSportHandler
+    private val hitterRecordClient: HitterRecordClient,
+    private val hitterGameRecordService: HitterGameRecordService
 ) {
 
     @Async
@@ -37,7 +39,7 @@ class GameHandler(
         )
 
         gameEndEventJobRepository.save(gameEndEventJob)
-        naverSportHandler.run(gameId = gameId)
+        updateHitterRecord(gameId)
     }
 
     /**
@@ -52,7 +54,7 @@ class GameHandler(
         logInfo("Game is Running: $gameId")
 
         gameService.run(gameId)
-        naverSportHandler.run(gameId = gameId)
+        updateHitterRecord(gameId)
     }
 
     /**
@@ -80,6 +82,11 @@ class GameHandler(
         )
 
         gameEndEventJobRepository.save(gameEndEventJob)
+    }
+
+    private fun updateHitterRecord(gameId: Long) {
+        val hitterRecords = hitterRecordClient.findAll(gameId)
+        hitterGameRecordService.saveOrUpdateHitterRecords(gameId, hitterRecords)
     }
 }
 

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameQueryService.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameQueryService.kt
@@ -3,7 +3,7 @@ package com.example.kbocombo.game.application
 import com.example.kbocombo.game.domain.Game
 import com.example.kbocombo.game.domain.vo.GameState
 import com.example.kbocombo.game.infra.GameQueryRepository
-import com.example.kbocombo.player.Player
+import com.example.kbocombo.player.domain.Player
 import com.example.kbocombo.player.vo.Team
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
@@ -72,6 +72,10 @@ class Game(
         this.startTime = gameStartTime
     }
 
+    fun isPending(): Boolean {
+        return gameState == GameState.PENDING
+    }
+
     fun isRunning(): Boolean {
         return gameState == GameState.RUNNING
     }

--- a/src/main/kotlin/com/example/kbocombo/game/infra/GameQueryRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/infra/GameQueryRepository.kt
@@ -2,8 +2,8 @@ package com.example.kbocombo.game.infra
 
 import com.example.kbocombo.game.domain.Game
 import com.example.kbocombo.game.domain.QGame.game
-import com.example.kbocombo.player.Player
 import com.example.kbocombo.player.QPlayer.player
+import com.example.kbocombo.player.domain.Player
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
 import java.time.LocalDate

--- a/src/main/kotlin/com/example/kbocombo/game/infra/GameQueryRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/infra/GameQueryRepository.kt
@@ -2,8 +2,8 @@ package com.example.kbocombo.game.infra
 
 import com.example.kbocombo.game.domain.Game
 import com.example.kbocombo.game.domain.QGame.game
-import com.example.kbocombo.player.QPlayer.player
 import com.example.kbocombo.player.domain.Player
+import com.example.kbocombo.player.domain.QPlayer.player
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
 import java.time.LocalDate

--- a/src/main/kotlin/com/example/kbocombo/player/domain/Player.kt
+++ b/src/main/kotlin/com/example/kbocombo/player/domain/Player.kt
@@ -1,4 +1,4 @@
-package com.example.kbocombo.player
+package com.example.kbocombo.player.domain
 
 import com.example.kbocombo.common.BaseEntity
 import com.example.kbocombo.player.vo.HittingHandType

--- a/src/main/kotlin/com/example/kbocombo/player/infra/HitterQueryRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/player/infra/HitterQueryRepository.kt
@@ -1,7 +1,7 @@
 package com.example.kbocombo.player.infra
 
-import com.example.kbocombo.player.Player
 import com.example.kbocombo.player.QPlayer.player
+import com.example.kbocombo.player.domain.Player
 import com.example.kbocombo.player.presentation.request.HitterTeamRequest
 import com.example.kbocombo.player.vo.PlayerPosition
 import com.querydsl.jpa.impl.JPAQueryFactory

--- a/src/main/kotlin/com/example/kbocombo/player/infra/HitterQueryRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/player/infra/HitterQueryRepository.kt
@@ -1,7 +1,7 @@
 package com.example.kbocombo.player.infra
 
-import com.example.kbocombo.player.QPlayer.player
 import com.example.kbocombo.player.domain.Player
+import com.example.kbocombo.player.domain.QPlayer.player
 import com.example.kbocombo.player.presentation.request.HitterTeamRequest
 import com.example.kbocombo.player.vo.PlayerPosition
 import com.querydsl.jpa.impl.JPAQueryFactory

--- a/src/main/kotlin/com/example/kbocombo/player/infra/PlayerRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/player/infra/PlayerRepository.kt
@@ -1,6 +1,6 @@
 package com.example.kbocombo.player.infra
 
-import com.example.kbocombo.player.Player
+import com.example.kbocombo.player.domain.Player
 import com.example.kbocombo.player.vo.WebId
 import org.springframework.data.repository.Repository
 

--- a/src/main/kotlin/com/example/kbocombo/player/infra/PlayerRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/player/infra/PlayerRepository.kt
@@ -20,5 +20,5 @@ interface PlayerRepository : Repository<Player, Long> {
 
     fun findByWebId(webId: WebId) : Player?
 
-    fun findAllByWebIdIn(webIds: Set<WebId>) : List<Player>
+    fun findAllByWebIdIn(webIds: List<Long>) : List<Player>
 }

--- a/src/main/kotlin/com/example/kbocombo/player/infra/PlayerRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/player/infra/PlayerRepository.kt
@@ -19,4 +19,6 @@ interface PlayerRepository : Repository<Player, Long> {
     fun findById(playerId: Long): Player?
 
     fun findByWebId(webId: WebId) : Player?
+
+    fun findAllByWebIdIn(webIds: Set<WebId>) : List<Player>
 }

--- a/src/main/kotlin/com/example/kbocombo/player/presentation/response/HitterTeamResponse.kt
+++ b/src/main/kotlin/com/example/kbocombo/player/presentation/response/HitterTeamResponse.kt
@@ -1,6 +1,6 @@
 package com.example.kbocombo.player.presentation.response
 
-import com.example.kbocombo.player.Player
+import com.example.kbocombo.player.domain.Player
 import com.example.kbocombo.player.vo.HittingHandType
 import com.example.kbocombo.player.vo.PlayerDetailPosition
 import com.example.kbocombo.player.vo.Team

--- a/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
@@ -1,6 +1,7 @@
 package com.example.kbocombo.record.application
 
-import com.example.kbocombo.common.logWarn
+import com.example.kbocombo.common.logInfo
+import com.example.kbocombo.crawler.game.infra.dto.HitterRecordDto
 import com.example.kbocombo.game.domain.Game
 import com.example.kbocombo.game.infra.GameRepository
 import com.example.kbocombo.player.domain.Player
@@ -19,15 +20,6 @@ class HitterGameRecordService(
 ) {
 
     @Transactional
-    fun deleteAllHitterRecordIfGameCanceled(game: Game) {
-        if (game.isCancelled().not()) {
-            logWarn("game is not canceled")
-            return
-        }
-        hitterGameRecordRepository.deleteAllByGameId(gameId = game.id)
-    }
-
-    @Transactional
     fun saveOrUpdateHitterRecords(gameId: Long, hitterRecordDtos: List<HitterRecordDto>) {
         val game = gameRepository.findById(gameId = gameId)
             ?: throw IllegalArgumentException("cannot find game")
@@ -37,6 +29,15 @@ class HitterGameRecordService(
         val hitterGameRecords = hitterGameRecordRepository.findAllByGameId(game.id)
             .associateBy { it.playerId }
         saveOrUpdate(requestByWebId, hitterGameRecords, game)
+    }
+
+    @Transactional
+    fun deleteAllHitterRecordIfGameCanceled(game: Game) {
+        if (game.isCancelled().not()) {
+            logInfo("game(gameId = ${game.id}) is not canceled")
+            return
+        }
+        hitterGameRecordRepository.deleteAllByGameId(gameId = game.id)
     }
 
     private fun saveOrUpdate(
@@ -70,10 +71,3 @@ class HitterGameRecordService(
         )
     }
 }
-
-
-data class HitterRecordDto(
-    val webId: WebId,
-    val atBats: Int,
-    val hits: Int
-)

--- a/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
@@ -1,5 +1,9 @@
 package com.example.kbocombo.record.application
 
+import com.example.kbocombo.game.infra.GameRepository
+import com.example.kbocombo.player.infra.PlayerRepository
+import com.example.kbocombo.player.vo.WebId
+import com.example.kbocombo.record.domain.HitterGameRecord
 import com.example.kbocombo.record.infra.HitterGameRecordRepository
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
@@ -9,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class HitterGameRecordService(
+    private val gameRepository: GameRepository,
+    private val playerRepository: PlayerRepository,
     private val hitterGameRecordRepository: HitterGameRecordRepository
 ) {
 
@@ -18,8 +24,41 @@ class HitterGameRecordService(
     fun deleteAllHitterRecordByGame(event: GameDomainCanceledEvent) {
         hitterGameRecordRepository.deleteByGameId(event.gameId)
     }
+
+    @Transactional
+    fun saveOrUpdateHitterRecords(gameCode: String, playerRecordRequest: List<PlayerRequest>) {
+        val requestByWebId = playerRecordRequest.associateBy { it.webId }
+        val game = gameRepository.findByGameCode(gameCode)
+            ?: throw IllegalArgumentException("존재하지 않는 게임입니다.")
+        if (game.isPending()) {
+            return
+        }
+        val players = playerRepository.findAllByWebIdIn(requestByWebId.keys)
+        val hitterGameRecords = hitterGameRecordRepository.findAllByGameId(game.id)
+            .associateBy { it.playerId }
+        for (player in players) {
+            val hitterGameRecord = hitterGameRecords[player.id]
+            val request = requestByWebId[player.webId]!!
+            if (hitterGameRecord == null) {
+                hitterGameRecordRepository.save(HitterGameRecord(gameId = game.id,
+                    gameDate = game.startDate,
+                    playerId = player.id,
+                    pa = request.pa,
+                    hit = request.hit,
+                    ))
+                continue
+            }
+            hitterGameRecord.updateStat(pa = request.pa, hit = hitterGameRecord.hit)
+        }
+    }
 }
 
 
 
 data class GameDomainCanceledEvent(val gameId: Long)
+
+data class PlayerRequest(
+    val webId: WebId,
+    val pa: Int,
+    val hit: Int
+)

--- a/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
@@ -30,7 +30,7 @@ class HitterGameRecordService(
     @Transactional
     fun saveOrUpdateHitterRecords(gameId: Long, hitterRecordDtos: List<HitterRecordDto>) {
         val game = gameRepository.findById(gameId = gameId)
-            ?: throw IllegalArgumentException("존재하지 않는 게임입니다.")
+            ?: throw IllegalArgumentException("cannot find game")
         if (game.isPending()) return
 
         val requestByWebId = hitterRecordDtos.associateBy { it.webId }

--- a/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
@@ -1,0 +1,25 @@
+package com.example.kbocombo.record.application
+
+import com.example.kbocombo.record.infra.HitterGameRecordRepository
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class HitterGameRecordService(
+    private val hitterGameRecordRepository: HitterGameRecordRepository
+) {
+
+    @Async
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun deleteAllHitterRecordByGame(event: GameDomainCanceledEvent) {
+        hitterGameRecordRepository.deleteByGameId(event.gameId)
+    }
+}
+
+
+
+data class GameDomainCanceledEvent(val gameId: Long)

--- a/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
@@ -44,7 +44,7 @@ class HitterGameRecordService(
         hitterGameRecords: Map<Long, HitterGameRecord>,
         game: Game
     ) {
-        val players = playerRepository.findAllByWebIdIn(requestByWebId.keys)
+        val players = playerRepository.findAllByWebIdIn(requestByWebId.keys.map { it.value })
         players.forEach { player ->
             val request = requestByWebId[player.webId]!!
             hitterGameRecords[player.id]

--- a/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
@@ -1,6 +1,8 @@
 package com.example.kbocombo.record.application
 
+import com.example.kbocombo.game.domain.Game
 import com.example.kbocombo.game.infra.GameRepository
+import com.example.kbocombo.player.domain.Player
 import com.example.kbocombo.player.infra.PlayerRepository
 import com.example.kbocombo.player.vo.WebId
 import com.example.kbocombo.record.domain.HitterGameRecord
@@ -27,32 +29,46 @@ class HitterGameRecordService(
 
     @Transactional
     fun saveOrUpdateHitterRecords(gameCode: String, playerRecordRequest: List<PlayerRequest>) {
-        val requestByWebId = playerRecordRequest.associateBy { it.webId }
         val game = gameRepository.findByGameCode(gameCode)
             ?: throw IllegalArgumentException("존재하지 않는 게임입니다.")
-        if (game.isPending()) {
-            return
-        }
-        val players = playerRepository.findAllByWebIdIn(requestByWebId.keys)
+        if (game.isPending()) return
+
+        val requestByWebId = playerRecordRequest.associateBy { it.webId }
         val hitterGameRecords = hitterGameRecordRepository.findAllByGameId(game.id)
             .associateBy { it.playerId }
-        for (player in players) {
-            val hitterGameRecord = hitterGameRecords[player.id]
+        saveOrUpdate(requestByWebId, hitterGameRecords, game)
+    }
+
+    private fun saveOrUpdate(
+        requestByWebId: Map<WebId, PlayerRequest>,
+        hitterGameRecords: Map<Long, HitterGameRecord>,
+        game: Game
+    ) {
+        val players = playerRepository.findAllByWebIdIn(requestByWebId.keys)
+        players.forEach { player ->
             val request = requestByWebId[player.webId]!!
-            if (hitterGameRecord == null) {
-                hitterGameRecordRepository.save(HitterGameRecord(gameId = game.id,
-                    gameDate = game.startDate,
-                    playerId = player.id,
-                    pa = request.pa,
-                    hit = request.hit,
-                    ))
-                continue
-            }
-            hitterGameRecord.updateStat(pa = request.pa, hit = hitterGameRecord.hit)
+            hitterGameRecords[player.id]
+                ?.let { updateHitterRecord(it, request) }
+                ?: saveHitterRecord(game, player, request)
         }
     }
-}
 
+    private fun updateHitterRecord(hitterGameRecord: HitterGameRecord, request: PlayerRequest) {
+        hitterGameRecord.updateStat(pa = request.pa, hit = hitterGameRecord.hit)
+    }
+
+    private fun saveHitterRecord(game: Game, player: Player, request: PlayerRequest) {
+        hitterGameRecordRepository.save(
+            HitterGameRecord(
+                gameId = game.id,
+                gameDate = game.startDate,
+                playerId = player.id,
+                pa = request.pa,
+                hit = request.hit
+            )
+        )
+    }
+}
 
 
 data class GameDomainCanceledEvent(val gameId: Long)

--- a/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
@@ -1,5 +1,6 @@
 package com.example.kbocombo.record.application
 
+import com.example.kbocombo.common.logWarn
 import com.example.kbocombo.game.domain.Game
 import com.example.kbocombo.game.infra.GameRepository
 import com.example.kbocombo.player.domain.Player
@@ -20,6 +21,7 @@ class HitterGameRecordService(
     @Transactional
     fun deleteAllHitterRecordIfGameCanceled(game: Game) {
         if (game.isCancelled().not()) {
+            logWarn("game is not canceled")
             return
         }
         hitterGameRecordRepository.deleteAllByGameId(gameId = game.id)

--- a/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
@@ -54,7 +54,7 @@ class HitterGameRecordService(
     }
 
     private fun updateHitterRecord(hitterGameRecord: HitterGameRecord, request: HitterRecordDto) {
-        hitterGameRecord.updateStat(pa = request.pa, hit = request.hit)
+        hitterGameRecord.updateStat(pa = request.atBats, hit = request.hits)
         hitterGameRecordRepository.save(hitterGameRecord)
     }
 
@@ -64,8 +64,8 @@ class HitterGameRecordService(
                 gameId = game.id,
                 gameDate = game.startDate,
                 playerId = player.id,
-                pa = request.pa,
-                hit = request.hit
+                atBats = request.atBats,
+                hits = request.hits
             )
         )
     }
@@ -74,6 +74,6 @@ class HitterGameRecordService(
 
 data class HitterRecordDto(
     val webId: WebId,
-    val pa: Int,
-    val hit: Int
+    val atBats: Int,
+    val hits: Int
 )

--- a/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
@@ -7,10 +7,7 @@ import com.example.kbocombo.player.infra.PlayerRepository
 import com.example.kbocombo.player.vo.WebId
 import com.example.kbocombo.record.domain.HitterGameRecord
 import com.example.kbocombo.record.infra.HitterGameRecordRepository
-import org.springframework.context.event.EventListener
-import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 @Service
@@ -20,11 +17,10 @@ class HitterGameRecordService(
     private val hitterGameRecordRepository: HitterGameRecordRepository
 ) {
 
-    @Async
-    @EventListener
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    fun deleteAllHitterRecordByGame(event: GameDomainCanceledEvent) {
-        hitterGameRecordRepository.deleteByGameId(event.gameId)
+    @Transactional
+    fun deleteAllHitterRecordIfGameCanceled(game: Game) {
+        require(game.isCancelled()) {"게임이 종료 상태가 아닙니다."}
+        hitterGameRecordRepository.deleteAllByGameId(gameId = game.id)
     }
 
     @Transactional
@@ -70,8 +66,6 @@ class HitterGameRecordService(
     }
 }
 
-
-data class GameDomainCanceledEvent(val gameId: Long)
 
 data class PlayerRequest(
     val webId: WebId,

--- a/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
@@ -50,7 +50,8 @@ class HitterGameRecordService(
     }
 
     private fun updateHitterRecord(hitterGameRecord: HitterGameRecord, request: PlayerRequest) {
-        hitterGameRecord.updateStat(pa = request.pa, hit = hitterGameRecord.hit)
+        hitterGameRecord.updateStat(pa = request.pa, hit = request.hit)
+        hitterGameRecordRepository.save(hitterGameRecord)
     }
 
     private fun saveHitterRecord(game: Game, player: Player, request: PlayerRequest) {

--- a/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
@@ -26,19 +26,19 @@ class HitterGameRecordService(
     }
 
     @Transactional
-    fun saveOrUpdateHitterRecords(gameCode: String, playerRecordRequest: List<PlayerRequest>) {
-        val game = gameRepository.findByGameCode(gameCode)
+    fun saveOrUpdateHitterRecords(gameId: Long, hitterRecordDtos: List<HitterRecordDto>) {
+        val game = gameRepository.findById(gameId = gameId)
             ?: throw IllegalArgumentException("존재하지 않는 게임입니다.")
         if (game.isPending()) return
 
-        val requestByWebId = playerRecordRequest.associateBy { it.webId }
+        val requestByWebId = hitterRecordDtos.associateBy { it.webId }
         val hitterGameRecords = hitterGameRecordRepository.findAllByGameId(game.id)
             .associateBy { it.playerId }
         saveOrUpdate(requestByWebId, hitterGameRecords, game)
     }
 
     private fun saveOrUpdate(
-        requestByWebId: Map<WebId, PlayerRequest>,
+        requestByWebId: Map<WebId, HitterRecordDto>,
         hitterGameRecords: Map<Long, HitterGameRecord>,
         game: Game
     ) {
@@ -51,12 +51,12 @@ class HitterGameRecordService(
         }
     }
 
-    private fun updateHitterRecord(hitterGameRecord: HitterGameRecord, request: PlayerRequest) {
+    private fun updateHitterRecord(hitterGameRecord: HitterGameRecord, request: HitterRecordDto) {
         hitterGameRecord.updateStat(pa = request.pa, hit = request.hit)
         hitterGameRecordRepository.save(hitterGameRecord)
     }
 
-    private fun saveHitterRecord(game: Game, player: Player, request: PlayerRequest) {
+    private fun saveHitterRecord(game: Game, player: Player, request: HitterRecordDto) {
         hitterGameRecordRepository.save(
             HitterGameRecord(
                 gameId = game.id,
@@ -70,7 +70,7 @@ class HitterGameRecordService(
 }
 
 
-data class PlayerRequest(
+data class HitterRecordDto(
     val webId: WebId,
     val pa: Int,
     val hit: Int

--- a/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
@@ -19,7 +19,9 @@ class HitterGameRecordService(
 
     @Transactional
     fun deleteAllHitterRecordIfGameCanceled(game: Game) {
-        require(game.isCancelled()) {"게임이 종료 상태가 아닙니다."}
+        if (game.isCancelled().not()) {
+            return
+        }
         hitterGameRecordRepository.deleteAllByGameId(gameId = game.id)
     }
 

--- a/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
@@ -4,6 +4,7 @@ import com.example.kbocombo.common.logInfo
 import com.example.kbocombo.crawler.game.infra.dto.HitterRecordDto
 import com.example.kbocombo.game.domain.Game
 import com.example.kbocombo.game.infra.GameRepository
+import com.example.kbocombo.game.infra.getById
 import com.example.kbocombo.player.domain.Player
 import com.example.kbocombo.player.infra.PlayerRepository
 import com.example.kbocombo.player.vo.WebId
@@ -21,8 +22,7 @@ class HitterGameRecordService(
 
     @Transactional
     fun saveOrUpdateHitterRecords(gameId: Long, hitterRecordDtos: List<HitterRecordDto>) {
-        val game = gameRepository.findById(gameId = gameId)
-            ?: throw IllegalArgumentException("cannot find game")
+        val game = gameRepository.getById(gameId = gameId)
         if (game.isPending()) return
 
         val requestByWebId = hitterRecordDtos.associateBy { it.webId }

--- a/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/application/HitterGameRecordService.kt
@@ -54,7 +54,7 @@ class HitterGameRecordService(
     }
 
     private fun updateHitterRecord(hitterGameRecord: HitterGameRecord, request: HitterRecordDto) {
-        hitterGameRecord.updateStat(pa = request.atBats, hit = request.hits)
+        hitterGameRecord.updateStat(atBats = request.atBats, hits = request.hits)
         hitterGameRecordRepository.save(hitterGameRecord)
     }
 

--- a/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
@@ -1,12 +1,12 @@
 package com.example.kbocombo.record.domain
 
+import com.example.kbocombo.common.AggregateBaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.PostPersist
-import org.springframework.data.domain.AbstractAggregateRoot
 import java.time.LocalDate
 
 @Entity(name = "HITTER_GAME_RECORD")
@@ -27,7 +27,7 @@ class HitterGameRecord(
     atBats: Int,
 
     hits: Int,
-) : AbstractAggregateRoot<HitterGameRecord>() {
+) : AggregateBaseEntity<HitterGameRecord>() {
 
     // 타수 AB
     @Column(name = "at_bats", nullable = false)

--- a/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
@@ -23,12 +23,18 @@ class HitterGameRecord(
     @Column(name = "player_id", nullable = false)
     val playerId: Long,
 
+    pa: Int,
+
+    hit: Int,
+) : BaseEntity() {
+
     @Column(name = "pa", nullable = false)
-    var pa: Int,
+    var pa: Int = pa
+        protected set
 
     @Column(name = "hit", nullable = false)
-    var hit: Int,
-) : BaseEntity() {
+    var hit: Int = hit
+        protected set
 
     fun updateStat(pa: Int, hit: Int) {
         this.pa = pa

--- a/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
@@ -24,32 +24,33 @@ class HitterGameRecord(
     @Column(name = "player_id", nullable = false)
     val playerId: Long,
 
-    pa: Int,
+    atBats: Int,
 
-    hit: Int,
+    hits: Int,
 ) : AbstractAggregateRoot<HitterGameRecord>() {
 
-    @Column(name = "pa", nullable = false)
-    var pa: Int = pa
+
+    @Column(name = "at_bats", nullable = false)
+    var atBats: Int = atBats
         protected set
 
-    @Column(name = "hit", nullable = false)
-    var hit: Int = hit
+    @Column(name = "hits", nullable = false)
+    var hits: Int = hits
         protected set
 
     @PostPersist
     fun publishHitterHitRecordEvent() {
-        if (hit > 0) {
+        if (hits > 0) {
             registerHitterHitRecordEvent()
         }
     }
 
     fun updateStat(pa: Int, hit: Int) {
-        this.pa = pa
-        if (this.hit == 0 && hit > 0) {
+        this.atBats = pa
+        if (this.hits == 0 && hit > 0) {
             registerHitterHitRecordEvent()
         }
-        this.hit = hit
+        this.hits = hit
     }
 
     private fun registerHitterHitRecordEvent() {

--- a/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
@@ -41,3 +41,11 @@ class HitterGameRecord(
         this.hit = hit
     }
 }
+
+data class HitterGameRecordSaveEvent(
+    val id: Long
+)
+
+data class HitterGameRe(
+    val id: Long
+)

--- a/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
@@ -30,10 +30,12 @@ class HitterGameRecord(
 ) : AbstractAggregateRoot<HitterGameRecord>() {
 
 
+    // 타수 AB
     @Column(name = "at_bats", nullable = false)
     var atBats: Int = atBats
         protected set
 
+    // 안타
     @Column(name = "hits", nullable = false)
     var hits: Int = hits
         protected set

--- a/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
@@ -47,12 +47,12 @@ class HitterGameRecord(
         }
     }
 
-    fun updateStat(pa: Int, hit: Int) {
-        this.atBats = pa
-        if (this.hits == 0 && hit > 0) {
+    fun updateStat(atBats: Int, hits: Int) {
+        this.atBats = atBats
+        if (this.hits == 0 && hits > 0) {
             registerHitterHitRecordEvent()
         }
-        this.hits = hit
+        this.hits = hits
     }
 
     private fun registerHitterHitRecordEvent() {

--- a/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
@@ -29,7 +29,6 @@ class HitterGameRecord(
     hits: Int,
 ) : AbstractAggregateRoot<HitterGameRecord>() {
 
-
     // 타수 AB
     @Column(name = "at_bats", nullable = false)
     var atBats: Int = atBats

--- a/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
@@ -1,0 +1,30 @@
+package com.example.kbocombo.record.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import java.time.LocalDate
+
+@Entity(name = "HITTER_GAME_RECORD")
+class HitterGameRecord(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(name = "game_id", nullable = false)
+    val gameId: Long,
+
+    @Column(name = "game_date", nullable = false)
+    val gameDate: LocalDate,
+
+    @Column(name = "player_id", nullable = false)
+    val playerId: Long,
+
+    @Column(name = "pa", nullable = false)
+    val pa: Int,
+
+    @Column(name = "hit", nullable = false)
+    val hit: Int,
+)

--- a/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
@@ -1,5 +1,6 @@
 package com.example.kbocombo.record.domain
 
+import com.example.kbocombo.common.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
@@ -27,7 +28,8 @@ class HitterGameRecord(
 
     @Column(name = "hit", nullable = false)
     var hit: Int,
-) {
+) : BaseEntity() {
+
     fun updateStat(pa: Int, hit: Int) {
         this.pa = pa
         this.hit = hit

--- a/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/domain/HitterGameRecord.kt
@@ -23,8 +23,13 @@ class HitterGameRecord(
     val playerId: Long,
 
     @Column(name = "pa", nullable = false)
-    val pa: Int,
+    var pa: Int,
 
     @Column(name = "hit", nullable = false)
-    val hit: Int,
-)
+    var hit: Int,
+) {
+    fun updateStat(pa: Int, hit: Int) {
+        this.pa = pa
+        this.hit = hit
+    }
+}

--- a/src/main/kotlin/com/example/kbocombo/record/infra/HitterGameRecordRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/infra/HitterGameRecordRepository.kt
@@ -15,4 +15,8 @@ interface HitterGameRecordRepository : Repository<HitterGameRecord, Long> {
         """
     )
     fun deleteByGameId(gameId: Long)
+
+    fun save(gameRecord: HitterGameRecord): HitterGameRecord
+
+    fun findAllByGameId(gameId: Long): List<HitterGameRecord>
 }

--- a/src/main/kotlin/com/example/kbocombo/record/infra/HitterGameRecordRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/infra/HitterGameRecordRepository.kt
@@ -19,4 +19,5 @@ interface HitterGameRecordRepository : Repository<HitterGameRecord, Long> {
     fun save(gameRecord: HitterGameRecord): HitterGameRecord
 
     fun findAllByGameId(gameId: Long): List<HitterGameRecord>
+    fun pa(pa: Int): MutableList<HitterGameRecord>
 }

--- a/src/main/kotlin/com/example/kbocombo/record/infra/HitterGameRecordRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/infra/HitterGameRecordRepository.kt
@@ -19,5 +19,4 @@ interface HitterGameRecordRepository : Repository<HitterGameRecord, Long> {
     fun save(gameRecord: HitterGameRecord): HitterGameRecord
 
     fun findAllByGameId(gameId: Long): List<HitterGameRecord>
-    fun pa(pa: Int): MutableList<HitterGameRecord>
 }

--- a/src/main/kotlin/com/example/kbocombo/record/infra/HitterGameRecordRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/infra/HitterGameRecordRepository.kt
@@ -1,0 +1,18 @@
+package com.example.kbocombo.record.infra
+
+import com.example.kbocombo.record.domain.HitterGameRecord
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.Repository
+
+interface HitterGameRecordRepository : Repository<HitterGameRecord, Long> {
+
+    @Modifying
+    @Query(
+        """
+            delete from HITTER_GAME_RECORD r
+            where r.gameId = :gameId
+        """
+    )
+    fun deleteByGameId(gameId: Long)
+}

--- a/src/main/kotlin/com/example/kbocombo/record/infra/HitterGameRecordRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/record/infra/HitterGameRecordRepository.kt
@@ -14,7 +14,7 @@ interface HitterGameRecordRepository : Repository<HitterGameRecord, Long> {
             where r.gameId = :gameId
         """
     )
-    fun deleteByGameId(gameId: Long)
+    fun deleteAllByGameId(gameId: Long)
 
     fun save(gameRecord: HitterGameRecord): HitterGameRecord
 

--- a/src/test/kotlin/com/example/kbocombo/combo/application/ComboServiceTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/combo/application/ComboServiceTest.kt
@@ -88,7 +88,7 @@ class ComboServiceTest(
                 )
             )
 
-            comboService.updateComboToSuccess(gameId = game.id, playerWebId = player.webId.value)
+            comboService.updateComboToSuccess(gameId = game.id, playerId = player.id)
 
             comboRepository.getById(combo.id).comboStatus shouldBe ComboStatus.PENDING
         }

--- a/src/test/kotlin/com/example/kbocombo/combo/application/ComboServiceTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/combo/application/ComboServiceTest.kt
@@ -63,7 +63,7 @@ class ComboServiceTest(
                 )
             )
 
-            comboService.updateComboToSuccess(gameId = game.id, playerWebId = playerA.webId.value)
+            comboService.updateComboToSuccess(gameId = game.id, playerId = playerA.id)
 
             comboRepository.getById(comboA.id).comboStatus shouldBe ComboStatus.SUCCESS
             comboRepository.getById(comboB.id).comboStatus shouldBe ComboStatus.PENDING

--- a/src/test/kotlin/com/example/kbocombo/combo/application/ComboServiceTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/combo/application/ComboServiceTest.kt
@@ -12,7 +12,7 @@ import com.example.kbocombo.game.infra.GameRepository
 import com.example.kbocombo.member.domain.Member
 import com.example.kbocombo.member.domain.vo.SocialProvider
 import com.example.kbocombo.member.infra.MemberRepository
-import com.example.kbocombo.player.Player
+import com.example.kbocombo.player.domain.Player
 import com.example.kbocombo.player.infra.PlayerRepository
 import com.example.kbocombo.utils.fixture
 import com.navercorp.fixturemonkey.kotlin.giveMeKotlinBuilder

--- a/src/test/kotlin/com/example/kbocombo/crawler/player/application/PlayerRenewServiceTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/crawler/player/application/PlayerRenewServiceTest.kt
@@ -1,7 +1,7 @@
 package com.example.kbocombo.crawler.player.application
 
 import com.example.kbocombo.mock.infra.FakePlayerRepository
-import com.example.kbocombo.player.Player
+import com.example.kbocombo.player.domain.Player
 import com.example.kbocombo.player.infra.PlayerRepository
 import com.example.kbocombo.player.vo.PlayerImage
 import com.example.kbocombo.utils.fixture

--- a/src/test/kotlin/com/example/kbocombo/mock/config/TestConfig.kt
+++ b/src/test/kotlin/com/example/kbocombo/mock/config/TestConfig.kt
@@ -1,0 +1,15 @@
+package com.example.kbocombo.mock.config
+
+import com.example.kbocombo.mock.event.CustomDefaultApplicationEvents
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.test.context.event.ApplicationEvents
+
+@TestConfiguration
+class TestConfig {
+
+    @Bean
+    fun applicationEvents(): ApplicationEvents {
+        return CustomDefaultApplicationEvents()
+    }
+}

--- a/src/test/kotlin/com/example/kbocombo/mock/event/CustomDefaultApplicationEvents.kt
+++ b/src/test/kotlin/com/example/kbocombo/mock/event/CustomDefaultApplicationEvents.kt
@@ -1,0 +1,39 @@
+package com.example.kbocombo.mock.event
+
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.PayloadApplicationEvent
+import org.springframework.context.event.EventListener
+import org.springframework.test.context.event.ApplicationEvents
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.stream.Stream
+
+class CustomDefaultApplicationEvents : ApplicationEvents {
+
+    private val events: MutableList<ApplicationEvent> = CopyOnWriteArrayList()
+
+    @EventListener
+    fun onApplicationEvent(event: ApplicationEvent) {
+        events.add(event)
+    }
+
+    override fun stream(): Stream<ApplicationEvent> {
+        return events.stream()
+    }
+
+    override fun <T> stream(type: Class<T>): Stream<T> {
+        val var10000: Stream<Any> = events.stream().map { source: ApplicationEvent -> this.unwrapPayloadEvent(source) }
+        return var10000.filter { obj: Any? -> type.isInstance(obj) }.map { obj: Any? -> type.cast(obj) }
+    }
+
+    override fun clear() {
+        events.clear()
+    }
+
+    private fun unwrapPayloadEvent(source: Any): Any {
+        return if (source is PayloadApplicationEvent<*>) {
+            source.payload
+        } else {
+            source
+        }
+    }
+}

--- a/src/test/kotlin/com/example/kbocombo/mock/infra/FakePlayerRepository.kt
+++ b/src/test/kotlin/com/example/kbocombo/mock/infra/FakePlayerRepository.kt
@@ -1,6 +1,6 @@
 package com.example.kbocombo.mock.infra
 
-import com.example.kbocombo.player.Player
+import com.example.kbocombo.player.domain.Player
 import com.example.kbocombo.player.infra.PlayerRepository
 import com.example.kbocombo.player.vo.WebId
 

--- a/src/test/kotlin/com/example/kbocombo/mock/infra/FakePlayerRepository.kt
+++ b/src/test/kotlin/com/example/kbocombo/mock/infra/FakePlayerRepository.kt
@@ -17,4 +17,8 @@ class FakePlayerRepository : BaseFakeRepository<Player>(Player::class), PlayerRe
     override fun findByWebId(webId: WebId): Player? {
         return db.find { it.webId == webId }
     }
+
+    override fun findAllByWebIdIn(webIds: List<Long>): List<Player> {
+        return db.filter { webIds.contains(it.webId.value)}
+    }
 }

--- a/src/test/kotlin/com/example/kbocombo/record/application/HitterGameRecordServiceTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/record/application/HitterGameRecordServiceTest.kt
@@ -1,5 +1,6 @@
 package com.example.kbocombo.record.application
 
+import com.example.kbocombo.annotation.IntegrationTest
 import com.example.kbocombo.crawler.game.infra.dto.HitterRecordDto
 import com.example.kbocombo.game.domain.Game
 import com.example.kbocombo.game.domain.vo.GameState
@@ -17,14 +18,11 @@ import io.kotest.core.spec.style.ExpectSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.event.ApplicationEvents
-import org.springframework.transaction.annotation.Transactional
 
 @Import(TestConfig::class)
-@Transactional
-@SpringBootTest
+@IntegrationTest
 class HitterGameRecordServiceTest(
     private val sut: HitterGameRecordService,
     private val gameRepository: GameRepository,

--- a/src/test/kotlin/com/example/kbocombo/record/application/HitterGameRecordServiceTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/record/application/HitterGameRecordServiceTest.kt
@@ -1,0 +1,132 @@
+package com.example.kbocombo.record.application
+
+import com.example.kbocombo.game.domain.Game
+import com.example.kbocombo.game.domain.vo.GameState
+import com.example.kbocombo.game.domain.vo.GameType
+import com.example.kbocombo.game.infra.GameRepository
+import com.example.kbocombo.mock.config.TestConfig
+import com.example.kbocombo.player.domain.Player
+import com.example.kbocombo.player.infra.PlayerRepository
+import com.example.kbocombo.record.domain.HitterGameRecord
+import com.example.kbocombo.record.domain.HitterHitRecordedEvent
+import com.example.kbocombo.record.infra.HitterGameRecordRepository
+import com.example.kbocombo.utils.fixture
+import com.navercorp.fixturemonkey.kotlin.giveMeKotlinBuilder
+import io.kotest.core.spec.style.ExpectSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.event.ApplicationEvents
+
+@Import(TestConfig::class)
+@SpringBootTest
+class HitterGameRecordServiceTest(
+    private val sut: HitterGameRecordService,
+    private val gameRepository: GameRepository,
+    private val playerRepository: PlayerRepository,
+    private val hitterGameRecordRepository: HitterGameRecordRepository,
+    private val applicationEvents: ApplicationEvents
+) : ExpectSpec({
+
+    beforeTest {
+        applicationEvents.clear()
+    }
+
+    context("타자 타격 기록 저장") {
+
+        expect("게임이 진행 예정이면 저장하지 않는다.") {
+            val game = gameRepository.save(getGame(GameState.PENDING).sample())
+            val playerA = playerRepository.save(getPlayer().sample())
+            val records = listOf(HitterRecordDto(webId = playerA.webId, atBats = 0, hits = 0))
+
+            sut.saveOrUpdateHitterRecords(gameId = game.id, hitterRecordDtos = records)
+
+            hitterGameRecordRepository.findAllByGameId(gameId = game.id) shouldHaveSize 0
+        }
+
+        expect("게임이 진행 예정이 아니고 DB에 존재하지 않으면 저장한다.") {
+            val game = gameRepository.save(getGame(GameState.RUNNING).sample())
+            val playerA = playerRepository.save(getPlayer().sample())
+            val playerB = playerRepository.save(getPlayer().sample())
+            val records = listOf(
+                HitterRecordDto(webId = playerA.webId, atBats = 0, hits = 0),
+                HitterRecordDto(webId = playerB.webId, atBats = 0, hits = 0)
+            )
+
+            sut.saveOrUpdateHitterRecords(gameId = game.id, hitterRecordDtos = records)
+
+            hitterGameRecordRepository.findAllByGameId(gameId = game.id) shouldHaveSize 2
+        }
+
+        expect("게임이 진행 예정이 아니고 DB에 존재하면 업데이트 한다.") {
+            val game = gameRepository.save(getGame(GameState.RUNNING).sample())
+            val player = playerRepository.save(getPlayer().sample())
+            hitterGameRecordRepository.save(
+                HitterGameRecord(
+                    gameId = game.id,
+                    gameDate = game.startDate,
+                    playerId = player.id,
+                    atBats = 0,
+                    hits = 0
+                )
+            )
+            val records = listOf(
+                HitterRecordDto(webId = player.webId, atBats = 4, hits = 2),
+            )
+
+            sut.saveOrUpdateHitterRecords(gameId = game.id, hitterRecordDtos = records)
+
+            val actual = hitterGameRecordRepository.findAllByGameId(gameId = game.id)[0]
+            actual.publishHitterHitRecordEvent()
+            actual.atBats shouldBe 4
+            actual.hits shouldBe 2
+        }
+
+        expect("안타가 1이상으로 저장되면 이벤트를 발행한다.") {
+            val game = gameRepository.save(getGame(GameState.RUNNING).sample())
+            val player = playerRepository.save(getPlayer().sample())
+            val records = listOf(
+                HitterRecordDto(webId = player.webId, atBats = 1, hits = 1),
+            )
+
+            sut.saveOrUpdateHitterRecords(gameId = game.id, hitterRecordDtos = records)
+
+            val event = applicationEvents.stream(HitterHitRecordedEvent::class.java).findFirst().get()!!
+            event.playerId shouldBe player.id
+            event.gameId shouldBe game.id
+        }
+
+        expect("안타가 0에서 1이상으로 변경되면 이벤트를 발행한다.") {
+            val game = gameRepository.save(getGame(GameState.RUNNING).sample())
+            val player = playerRepository.save(getPlayer().sample())
+            hitterGameRecordRepository.save(
+                HitterGameRecord(
+                    gameId = game.id,
+                    gameDate = game.startDate,
+                    playerId = player.id,
+                    atBats = 0,
+                    hits = 0
+                )
+            )
+            val records = listOf(
+                HitterRecordDto(webId = player.webId, atBats = 1, hits = 1),
+            )
+
+            sut.saveOrUpdateHitterRecords(gameId = game.id, hitterRecordDtos = records)
+
+            val event = applicationEvents.stream(HitterHitRecordedEvent::class.java).findFirst().get()!!
+            event.playerId shouldBe player.id
+            event.gameId shouldBe game.id
+        }
+    }
+})
+
+private fun getGame(gameState: GameState) = fixture.giveMeKotlinBuilder<Game>()
+    .setExp(Game::id, 0L)
+    .setExp(Game::gameType, GameType.REGULAR_SEASON)
+    .setExp(Game::gameState, gameState)
+
+private fun getPlayer() = fixture.giveMeKotlinBuilder<Player>()
+    .setExp(Player::id, 0L)
+    .setExp(Player::isRetired, false)

--- a/src/test/kotlin/com/example/kbocombo/record/application/HitterGameRecordServiceTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/record/application/HitterGameRecordServiceTest.kt
@@ -15,7 +15,7 @@ import com.example.kbocombo.record.infra.HitterGameRecordRepository
 import com.example.kbocombo.utils.fixture
 import com.navercorp.fixturemonkey.kotlin.giveMeKotlinBuilder
 import io.kotest.core.spec.style.ExpectSpec
-import io.kotest.datatest.withData
+import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import org.springframework.context.annotation.Import
@@ -108,20 +108,17 @@ class HitterGameRecordServiceTest(
     }
 
     context("타자 타격 기록 삭제") {
-        withData(
-            nameFn = { gameState -> "게임 상태가 ${gameState}이면 기록이 삭제되지 않아야 한다" },
-            GameState.entries.filter { it != GameState.CANCEL }
-        ) { gameState ->
-            // Given
-            val game = gameRepository.save(getGame(gameState).sample())
-            val player = playerRepository.save(getPlayer().sample())
-            hitterGameRecordRepository.save(getHitterGameRecord(game, player).sample())
+        expect("게임 상태가 취소가 아니라면 기록이 삭제되지 않아야한다") {
+            val gameStates = GameState.entries.filter { it != GameState.CANCEL }
+            gameStates.forAll { gameState ->
+                val game = gameRepository.save(getGame(gameState).sample())
+                val player = playerRepository.save(getPlayer().sample())
+                hitterGameRecordRepository.save(getHitterGameRecord(game, player).sample())
 
-            // When
-            sut.deleteAllHitterRecordIfGameCanceled(game)
+                sut.deleteAllHitterRecordIfGameCanceled(game)
 
-            // Then
-            hitterGameRecordRepository.findAllByGameId(game.id) shouldHaveSize 1
+                hitterGameRecordRepository.findAllByGameId(game.id) shouldHaveSize 1
+            }
         }
 
         expect("게임이 취소면 해당 게임의 타격기록을 모두 삭제한다.") {

--- a/src/test/kotlin/com/example/kbocombo/record/application/HitterGameRecordServiceTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/record/application/HitterGameRecordServiceTest.kt
@@ -18,8 +18,10 @@ import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.event.ApplicationEvents
+import org.springframework.transaction.annotation.Transactional
 
 @Import(TestConfig::class)
+@Transactional
 @SpringBootTest
 class HitterGameRecordServiceTest(
     private val sut: HitterGameRecordService,

--- a/src/test/kotlin/com/example/kbocombo/record/application/HitterGameRecordServiceTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/record/application/HitterGameRecordServiceTest.kt
@@ -1,5 +1,6 @@
 package com.example.kbocombo.record.application
 
+import com.example.kbocombo.crawler.game.infra.dto.HitterRecordDto
 import com.example.kbocombo.game.domain.Game
 import com.example.kbocombo.game.domain.vo.GameState
 import com.example.kbocombo.game.domain.vo.GameType
@@ -64,15 +65,7 @@ class HitterGameRecordServiceTest(
         expect("게임이 진행 예정이 아니고 DB에 존재하면 업데이트 한다.") {
             val game = gameRepository.save(getGame(GameState.RUNNING).sample())
             val player = playerRepository.save(getPlayer().sample())
-            hitterGameRecordRepository.save(
-                HitterGameRecord(
-                    gameId = game.id,
-                    gameDate = game.startDate,
-                    playerId = player.id,
-                    atBats = 0,
-                    hits = 0
-                )
-            )
+            hitterGameRecordRepository.save(getHitterGameRecord(game, player).sample())
             val records = listOf(
                 HitterRecordDto(webId = player.webId, atBats = 4, hits = 2),
             )
@@ -102,15 +95,7 @@ class HitterGameRecordServiceTest(
         expect("안타가 0에서 1이상으로 변경되면 이벤트를 발행한다.") {
             val game = gameRepository.save(getGame(GameState.RUNNING).sample())
             val player = playerRepository.save(getPlayer().sample())
-            hitterGameRecordRepository.save(
-                HitterGameRecord(
-                    gameId = game.id,
-                    gameDate = game.startDate,
-                    playerId = player.id,
-                    atBats = 0,
-                    hits = 0
-                )
-            )
+            hitterGameRecordRepository.save(getHitterGameRecord(game, player).sample())
             val records = listOf(
                 HitterRecordDto(webId = player.webId, atBats = 1, hits = 1),
             )
@@ -132,3 +117,14 @@ private fun getGame(gameState: GameState) = fixture.giveMeKotlinBuilder<Game>()
 private fun getPlayer() = fixture.giveMeKotlinBuilder<Player>()
     .setExp(Player::id, 0L)
     .setExp(Player::isRetired, false)
+
+private fun getHitterGameRecord(
+    game: Game,
+    player: Player
+)= fixture.giveMeKotlinBuilder<HitterGameRecord>()
+    .setExp(HitterGameRecord::id, 0L)
+    .setExp(HitterGameRecord::gameId, game.id)
+    .setExp(HitterGameRecord::gameDate, game.startDate)
+    .setExp(HitterGameRecord::playerId, player.id)
+    .setExp(HitterGameRecord::hits, 0)
+    .setExp(HitterGameRecord::atBats, 0)


### PR DESCRIPTION
조회 쿼리까지 짜기엔 PR이 너무 길어져서 여기서 조회 로직은 건드리지 않았습니다.

변경 내용은 타자의 게임별 타수 / 안타를 저장하는 ```HitterGameRecord``` 테이블을 추가했습니다. 도메인 이벤트도 적용해보았어요.


그 과정에서 기존의 콤보 성공 로직이 아래와 같았는데 변경했습니다.

**AS-IS**
1. 스케줄러에서 게임 조회 및 게임 상태에 따라 이벤트 발행
2. 게임이 진행 or 완료라면 게임 record 조회
3. 안타가 1 이상인 선수가 있으면 이벤트 발행(해당 이벤트에서 콤보 업데이트)


**TO-BE**
1. 스케줄러에서 게임 조회 및 게임 상태에 따라 이벤트 발행
2. 게임이 진행 or 완료라면 해당 게임의 모든 타자의 타수 / 안타 데이터를 조회
3. DB의 값과 비교해서 save Or Update
4. 만약 안타를 기록하면 이벤트 발행(0안타에서 -> n안타 , n> 0)
5. 해당 이벤트를 구독해서 콤보 업데이트




