### PR TITLE
게임 취소일시 콤보를 PASS 처리하지 못하던 문제를 수정한다.

### DIFF
--- a/src/main/kotlin/com/example/kbocombo/combo/application/ComboRankHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/application/ComboRankHandler.kt
@@ -1,0 +1,21 @@
+package com.example.kbocombo.combo.application
+
+import com.example.kbocombo.auth.application.MemberSignupedEvent
+import com.example.kbocombo.common.logInfo
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class ComboRankHandler(
+    private val comboRankService: ComboRankService
+) {
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleMemberSignupedEvent(memberSignupedEvent: MemberSignupedEvent) {
+        logInfo("Handle MemberSignuped event, memberId = ${memberSignupedEvent.memberId}")
+        comboRankService.create(memberId = memberSignupedEvent.memberId)
+    }
+}

--- a/src/main/kotlin/com/example/kbocombo/combo/application/ComboRankQueryService.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/application/ComboRankQueryService.kt
@@ -1,0 +1,158 @@
+package com.example.kbocombo.combo.application
+
+import com.example.kbocombo.combo.domain.ComboRank
+import com.example.kbocombo.combo.infra.ComboRankQueryRepository
+import com.example.kbocombo.combo.infra.ComboRankRepository
+import com.example.kbocombo.combo.infra.TopRankQueryDto
+import com.example.kbocombo.game.domain.vo.GameType
+import com.example.kbocombo.member.infra.MemberRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class ComboRankQueryService(
+    private val memberRepository: MemberRepository,
+    private val comboRankRepository: ComboRankRepository,
+    private val comboRankQueryRepository: ComboRankQueryRepository
+) {
+
+    @Transactional(readOnly = true)
+    fun getMemberComboRank(memberId: Long): List<MemberComboRankByYearResponse> {
+        val member = memberRepository.findById(memberId)
+
+        val comboRanks = comboRankRepository.findAllByMemberId(memberId = member.id)
+
+        return MemberComboRankByYearResponse.from(comboRanks)
+    }
+
+    @Transactional(readOnly = true)
+    fun getComboRankStatistic(year: Int, count: Int, gameType: GameType): TopComboRankResponse {
+        val topRanksDto = comboRankQueryRepository.findTopRanks(
+            year = year,
+            limit = count.toLong(),
+            gameType = gameType
+        )
+
+        val topRankResponses = calculateRankForDtos(topRanksDto)
+        return TopComboRankResponse(gameType = gameType.name, comboRankResponse = topRankResponses)
+    }
+
+    private fun calculateRankForDtos(dtos: List<TopRankQueryDto>): List<ComboRankResponse> {
+        var previousScore: Int? = null
+        var currentRank = 0
+        return dtos.mapIndexed { index, dto ->
+            if (previousScore == null || dto.currentRecord != previousScore) {
+                currentRank = index + 1
+            }
+            previousScore = dto.currentRecord
+            ComboRankResponse.of(dto, currentRank)
+        }
+    }
+}
+
+data class MemberComboRankByYearResponse(
+    val year: Int,
+    val comboRanks: MemberComboRankByGameType
+) {
+    companion object {
+        fun from(comboRanks: List<ComboRank>): List<MemberComboRankByYearResponse> {
+            return comboRanks.groupBy { it.years }
+                .map { (year, listForYear) ->
+                    MemberComboRankByYearResponse(
+                        year = year,
+                        comboRanks = MemberComboRankByGameType.from(listForYear)
+                    )
+                }
+                .sortedByDescending { it.year }
+        }
+    }
+}
+
+data class MemberComboRankByGameType(
+    val preSeason: MemberComboRankResponse?,
+    val regularSeason: MemberComboRankResponse?,
+    val postSeason: MemberComboRankResponse?
+) {
+    companion object {
+        fun from(comboRanks: List<ComboRank>): MemberComboRankByGameType {
+            val map = comboRanks.associateBy { it.gameType }
+            return MemberComboRankByGameType(
+                preSeason = map[GameType.PRE_SEASON]?.let { MemberComboRankResponse.from(it) },
+                regularSeason = map[GameType.REGULAR_SEASON]?.let { MemberComboRankResponse.from(it) },
+                postSeason = map[GameType.POST_SEASON]?.let { MemberComboRankResponse.from(it) },
+            )
+        }
+    }
+}
+
+data class MemberComboRankResponse(
+    val id: Long,
+    val year: Int,
+    val memberId: Long,
+    val gameType: GameType,
+    val currentRecord: Int,
+    val successCount: Int,
+    val failCount: Int,
+    val passCount: Int,
+    val totalCount: Int,
+    val firstSuccessDate: LocalDate?,
+    val lastSuccessDate: LocalDate?
+) {
+    companion object {
+        fun from(comboRank: ComboRank): MemberComboRankResponse {
+            return MemberComboRankResponse(
+                id = comboRank.id,
+                year = comboRank.years,
+                memberId = comboRank.memberId,
+                currentRecord = comboRank.currentRecord,
+                successCount = comboRank.successCount,
+                failCount = comboRank.failCount,
+                passCount = comboRank.passCount,
+                totalCount = comboRank.totalCount,
+                firstSuccessDate = comboRank.firstSuccessDate,
+                lastSuccessDate = comboRank.lastSuccessDate,
+                gameType = comboRank.gameType
+            )
+        }
+    }
+}
+
+data class TopComboRankResponse(
+    val gameType: String,
+    val comboRankResponse: List<ComboRankResponse>
+)
+
+data class ComboRankResponse(
+    val rank: Int,
+    val id: Long,
+    val year: Int,
+    val memberId: Long,
+    val nickname: String,
+    val currentRecord: Int,
+    val successCount: Int,
+    val failCount: Int,
+    val passCount: Int,
+    val totalCount: Int,
+    val firstSuccessDate: LocalDate?,
+    val lastSuccessDate: LocalDate?
+) {
+    companion object {
+        fun of(topRankQueryDto: TopRankQueryDto, rank: Int): ComboRankResponse {
+            return ComboRankResponse(
+                rank = rank,
+                id = topRankQueryDto.id,
+                year = topRankQueryDto.year,
+                memberId = topRankQueryDto.memberId,
+                nickname = topRankQueryDto.nickname,
+                currentRecord = topRankQueryDto.currentRecord,
+                successCount = topRankQueryDto.successCount,
+                failCount = topRankQueryDto.failCount,
+                passCount = topRankQueryDto.passCount,
+                totalCount = topRankQueryDto.totalCount,
+                firstSuccessDate = topRankQueryDto.firstSuccessDate,
+                lastSuccessDate = topRankQueryDto.lastSuccessDate
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/example/kbocombo/combo/application/ComboRankService.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/application/ComboRankService.kt
@@ -1,0 +1,71 @@
+package com.example.kbocombo.combo.application
+
+import com.example.kbocombo.combo.domain.Combo
+import com.example.kbocombo.combo.domain.ComboRank
+import com.example.kbocombo.combo.domain.vo.ComboStatus
+import com.example.kbocombo.combo.infra.ComboRankRepository
+import com.example.kbocombo.combo.infra.ComboRepository
+import com.example.kbocombo.common.logInfo
+import com.example.kbocombo.game.domain.Game
+import com.example.kbocombo.game.domain.vo.GameType
+import com.example.kbocombo.member.infra.MemberRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class ComboRankService(
+    private val memberRepository: MemberRepository,
+    private val comboRepository: ComboRepository,
+    private val comboRankRepository: ComboRankRepository,
+) {
+
+    @Transactional
+    fun process(game: Game) {
+        if (game.isRunning()) {
+            logInfo("아직 게임이 완료되지 않았습니다. gameId: ${game.id}")
+            return
+        }
+
+        val combos = comboRepository.findAllByGame(game)
+        combos.forEach { recordToRank(it, game) }
+    }
+
+    private fun recordToRank(combo: Combo, game: Game) {
+        val comboRank = findComboRankOrSave(combo = combo, game = game)
+
+        when (combo.comboStatus) {
+            ComboStatus.SUCCESS -> comboRank.recordComboSuccess(gameDate = combo.gameDate)
+            ComboStatus.FAIL -> comboRank.recordComboFail()
+            ComboStatus.PASS -> comboRank.recordComboPass()
+            ComboStatus.PENDING -> {}
+        }
+        comboRankRepository.save(comboRank)
+    }
+
+    private fun findComboRankOrSave(combo: Combo, game: Game): ComboRank {
+        val memberId = combo.memberId
+        val year = combo.gameDate.year
+        return comboRankRepository.findByMemberIdAndYears(memberId = memberId, years = year)
+            ?: comboRankRepository.save(
+                ComboRank.init(
+                    memberId = memberId,
+                    years = year,
+                    gameType = game.gameType
+                )
+            )
+    }
+
+    @Transactional
+    fun create(memberId: Long) {
+        val member = memberRepository.findById(memberId)
+        val today = LocalDate.now()
+
+        val comboRank = ComboRank.init(
+            memberId = member.id,
+            years = LocalDate.now().year,
+            gameType = GameType.getGameTypeByDate(gameDate = today)
+        )
+        comboRankRepository.save(comboRank)
+    }
+}

--- a/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
@@ -89,8 +89,8 @@ class ComboService(
     @Transactional
     fun updateComboToPass(gameId: Long) {
         val game = gameRepository.getById(gameId)
-        if (game.isCompleted().not()) {
-            throw IllegalArgumentException("게임이 종료되지 않은 경우, 콤보 패스 처리를 할 수 없습니다.")
+        if (game.isCancelled().not()) {
+            throw IllegalArgumentException("게임이 취소되지 않은 경우, 콤보 패스 처리를 할 수 없습니다.")
         }
 
         val combos = comboRepository.findAllByGame(game = game)

--- a/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
@@ -5,6 +5,7 @@ import com.example.kbocombo.combo.domain.Combo
 import com.example.kbocombo.combo.domain.vo.ComboStatus
 import com.example.kbocombo.combo.infra.ComboRepository
 import com.example.kbocombo.combo.infra.getById
+import com.example.kbocombo.common.logInfo
 import com.example.kbocombo.game.domain.Game
 import com.example.kbocombo.game.infra.GameRepository
 import com.example.kbocombo.game.infra.getById
@@ -50,7 +51,8 @@ class ComboService(
     fun updateComboToSuccess(gameId: Long, playerWebId: Long) {
         val game = gameRepository.getById(gameId)
         if (game.isRunning().not()) {
-            throw IllegalArgumentException("진행 중인 게임이 아닌 경우, 콤보 성공 처리를 할 수 없습니다.")
+            logInfo("진행 중인 게임이 아닌 경우, 콤보 성공 처리를 할 수 없습니다.")
+            return
         }
         val player = playerRepository.getByWebId(webId = WebId(playerWebId))
         val combos = comboRepository.findAllByGameAndPlayerIdAndComboStatus(

--- a/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
@@ -89,11 +89,6 @@ class ComboService(
     @Transactional
     fun updateComboToPass(gameId: Long, now: LocalDateTime) {
         val game = gameRepository.getById(gameId)
-
-        if (game.isAfterGameStart(now).not()) {
-            return
-        }
-
         if (game.isCancelled().not()) {
             throw IllegalArgumentException("게임이 취소되지 않은 경우, 콤보 패스 처리를 할 수 없습니다.")
         }

--- a/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
@@ -87,8 +87,13 @@ class ComboService(
     }
 
     @Transactional
-    fun updateComboToPass(gameId: Long) {
+    fun updateComboToPass(gameId: Long, now: LocalDateTime) {
         val game = gameRepository.getById(gameId)
+
+        if (game.isAfterGameStart(now).not()) {
+            return
+        }
+
         if (game.isCancelled().not()) {
             throw IllegalArgumentException("게임이 취소되지 않은 경우, 콤보 패스 처리를 할 수 없습니다.")
         }

--- a/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
@@ -13,6 +13,7 @@ import com.example.kbocombo.player.infra.PlayerRepository
 import com.example.kbocombo.player.infra.getById
 import com.example.kbocombo.player.infra.getByWebId
 import com.example.kbocombo.player.vo.WebId
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -22,6 +23,7 @@ class ComboService(
     private val gameRepository: GameRepository,
     private val playerRepository: PlayerRepository,
     private val comboRepository: ComboRepository,
+    private val publisher: ApplicationEventPublisher
 ) {
 
     @Transactional

--- a/src/main/kotlin/com/example/kbocombo/combo/domain/ComboRank.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/domain/ComboRank.kt
@@ -1,0 +1,114 @@
+package com.example.kbocombo.combo.domain
+
+import com.example.kbocombo.common.BaseEntity
+import com.example.kbocombo.game.domain.vo.GameType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.LocalDate
+
+@Entity(name = "COMBO_RANK")
+@Table(
+    uniqueConstraints = [
+        UniqueConstraint(columnNames = ["years", "game_type", "member_id"])
+    ]
+)
+class ComboRank(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(name = "years", nullable = false)
+    val years: Int,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "game_type", nullable = false)
+    val gameType: GameType,
+
+    @Column(name = "member_id", nullable = false)
+    val memberId: Long,
+
+    currentRecord: Int,
+    successCount: Int,
+    failCount: Int,
+    passCount: Int,
+    totalCount: Int,
+    firstSuccessDate: LocalDate? = null,
+    lastSuccessDate: LocalDate? = null
+) : BaseEntity() {
+
+    @Column(name = "current_record")
+    var currentRecord: Int = currentRecord
+        protected set
+
+    @Column(name = "success_count")
+    var successCount: Int = successCount
+        protected set
+
+    @Column(name = "fail_count")
+    var failCount: Int = failCount
+        protected set
+
+    @Column(name = "pass_count")
+    var passCount: Int = passCount
+        protected set
+
+    @Column(name = "total_count")
+    var totalCount: Int = totalCount
+        protected set
+
+    @Column(name = "first_success_date")
+    var firstSuccessDate: LocalDate? = firstSuccessDate
+        protected set
+
+    @Column(name = "last_success_date")
+    var lastSuccessDate: LocalDate? = lastSuccessDate
+        protected set
+
+
+    fun recordComboSuccess(gameDate: LocalDate) {
+        this.currentRecord += 1
+        this.successCount += 1
+        this.totalCount += 1
+        if (this.firstSuccessDate == null) {
+            this.firstSuccessDate = gameDate
+        }
+        this.lastSuccessDate = gameDate
+    }
+
+    fun recordComboFail() {
+        this.currentRecord = 0
+        this.failCount += 1
+        this.totalCount += 1
+        this.firstSuccessDate = null
+        this.lastSuccessDate = null
+    }
+
+    fun recordComboPass() {
+        this.passCount += 1
+        this.totalCount += 1
+    }
+
+    companion object {
+        fun init(memberId: Long, years: Int, gameType: GameType): ComboRank {
+            return ComboRank(
+                memberId = memberId,
+                years = years,
+                gameType = gameType,
+                currentRecord = 0,
+                successCount = 0,
+                totalCount = 0,
+                failCount = 0,
+                passCount = 0,
+                firstSuccessDate = null,
+                lastSuccessDate = null
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/example/kbocombo/combo/infra/ComboRankQueryRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/infra/ComboRankQueryRepository.kt
@@ -1,0 +1,59 @@
+package com.example.kbocombo.combo.infra
+
+import com.example.kbocombo.combo.domain.QComboRank.comboRank
+import com.example.kbocombo.game.domain.vo.GameType
+import com.example.kbocombo.member.domain.QMember.member
+import com.querydsl.core.annotations.QueryProjection
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+class ComboRankQueryRepository(
+    private val queryFactory: JPAQueryFactory
+) {
+    fun findTopRanks(year: Int, limit: Long, gameType: GameType): List<TopRankQueryDto> {
+        return queryFactory
+            .select(
+                QTopRankQueryDto(
+                    comboRank.id,
+                    comboRank.years,
+                    comboRank.memberId,
+                    comboRank.gameType,
+                    member.nickname,
+                    comboRank.currentRecord,
+                    comboRank.successCount,
+                    comboRank.failCount,
+                    comboRank.passCount,
+                    comboRank.totalCount,
+                    comboRank.firstSuccessDate,
+                    comboRank.lastSuccessDate
+                )
+            )
+            .from(comboRank)
+            .join(member).on(comboRank.memberId.eq(member.id))
+            .orderBy(comboRank.currentRecord.desc())
+            .limit(limit)
+            .where(
+                comboRank.years.eq(year),
+                comboRank.gameType.eq(gameType)
+            )
+            .fetch()
+    }
+
+}
+
+data class TopRankQueryDto @QueryProjection constructor(
+    val id: Long,
+    val year: Int,
+    val memberId: Long,
+    val gameType: GameType,
+    val nickname: String,
+    val currentRecord: Int,
+    val successCount: Int,
+    val failCount: Int,
+    val passCount: Int,
+    val totalCount: Int,
+    val firstSuccessDate: LocalDate?,
+    val lastSuccessDate: LocalDate?
+)

--- a/src/main/kotlin/com/example/kbocombo/combo/infra/ComboRankRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/infra/ComboRankRepository.kt
@@ -1,0 +1,13 @@
+package com.example.kbocombo.combo.infra
+
+import com.example.kbocombo.combo.domain.ComboRank
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ComboRankRepository : JpaRepository<ComboRank, Long> {
+
+    fun findAllByMemberId(memberId: Long): List<ComboRank>
+    fun save(comboRank: ComboRank): ComboRank
+    fun findByMemberIdAndYears(memberId: Long, years: Int): ComboRank?
+}

--- a/src/main/kotlin/com/example/kbocombo/combo/ui/ComboRankController.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/ui/ComboRankController.kt
@@ -1,0 +1,37 @@
+package com.example.kbocombo.combo.ui
+
+import com.example.kbocombo.combo.application.ComboRankQueryService
+import com.example.kbocombo.combo.application.MemberComboRankByYearResponse
+import com.example.kbocombo.combo.application.TopComboRankResponse
+import com.example.kbocombo.game.domain.vo.GameType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/combo-rank")
+class ComboRankController(
+    private val comboRankQueryService: ComboRankQueryService
+) {
+
+    @GetMapping("/detail")
+    fun findOne(
+        @RequestParam targetMemberId: Long,
+    ): ResponseEntity<List<MemberComboRankByYearResponse>> {
+        val response = comboRankQueryService.getMemberComboRank(memberId = targetMemberId)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/statistic")
+    fun findTopRankStatistic(
+        @RequestParam year: Int = LocalDate.now().year,
+        @RequestParam size: Int = 20,
+        @RequestParam gameType: GameType = GameType.REGULAR_SEASON
+    ): ResponseEntity<TopComboRankResponse> {
+        val response = comboRankQueryService.getComboRankStatistic(year = year, count = size, gameType = gameType)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/com/example/kbocombo/config/JpaConfig.kt
+++ b/src/main/kotlin/com/example/kbocombo/config/JpaConfig.kt
@@ -1,0 +1,9 @@
+package com.example.kbocombo.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@Configuration
+@EnableJpaAuditing
+class JpaConfig {
+}

--- a/src/main/kotlin/com/example/kbocombo/crawler/player/infra/KboPlayerDetailPageParser.kt
+++ b/src/main/kotlin/com/example/kbocombo/crawler/player/infra/KboPlayerDetailPageParser.kt
@@ -1,6 +1,6 @@
 package com.example.kbocombo.crawler.player.infra
 
-import com.example.kbocombo.common.logError
+import com.example.kbocombo.common.logWarn
 import com.example.kbocombo.crawler.common.utils.toHittingHand
 import com.example.kbocombo.crawler.common.utils.toPitchingHand
 import com.example.kbocombo.crawler.common.utils.toPlayerDetailPosition
@@ -24,7 +24,7 @@ class KboPlayerDetailPageParser {
 
     fun getPlayerProfile(playerData: WebPlayerInfo): Player? {
         return runCatching { toPlayer(playerData) }
-            .onFailure { e -> logError("Failed to parse player with ${playerData.webId}", e) }
+            .onFailure { e -> logWarn("Failed to parse player with ${playerData.webId}", e) }
             .getOrNull()
     }
 

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
@@ -19,11 +19,11 @@ class GameEndEventJobService(
 ) {
     
     @Transactional
-    fun process(gameEndEventJobId: Long) {
+    fun process(gameEndEventJobId: Long, now: LocalDateTime) {
         val gameEndEventJob = gameEndEventJobRepository.findById(gameEndEventJobId)
         val game = gameRepository.getById(gameEndEventJob.gameId)
 
-        if (game.isAfterGameStart(LocalDateTime.now()).not()) {
+        if (game.isAfterGameStart(now).not()) {
             return
         }
 

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
@@ -1,5 +1,6 @@
 package com.example.kbocombo.game.application
 
+import com.example.kbocombo.combo.application.ComboRankService
 import com.example.kbocombo.combo.application.ComboService
 import com.example.kbocombo.game.domain.vo.GameState
 import com.example.kbocombo.game.infra.GameEndEventJobRepository
@@ -13,6 +14,7 @@ class GameEndEventJobService(
     private val gameRepository: GameRepository,
     private val gameEndEventJobRepository: GameEndEventJobRepository,
     private val comboService: ComboService,
+    private val comboRankService: ComboRankService
 ) {
     
     @Transactional
@@ -25,6 +27,7 @@ class GameEndEventJobService(
             GameState.CANCEL -> comboService.updateComboToPass(gameId = game.id)
             else -> { }
         }
+        comboRankService.process(game = game)
 
         gameEndEventJob.finish()
         gameEndEventJobRepository.save(gameEndEventJob)

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
@@ -23,6 +23,10 @@ class GameEndEventJobService(
         val gameEndEventJob = gameEndEventJobRepository.findById(gameEndEventJobId)
         val game = gameRepository.getById(gameEndEventJob.gameId)
 
+        if (game.isAfterGameStart(LocalDateTime.now()).not()) {
+            return
+        }
+
         when (game.gameState) {
             GameState.COMPLETED -> comboService.updateComboToFail(gameId = game.id)
             GameState.CANCEL -> comboService.updateComboToPass(gameId = game.id, LocalDateTime.now())

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
@@ -8,6 +8,7 @@ import com.example.kbocombo.game.infra.GameRepository
 import com.example.kbocombo.game.infra.getById
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class GameEndEventJobService(
@@ -24,7 +25,7 @@ class GameEndEventJobService(
 
         when (game.gameState) {
             GameState.COMPLETED -> comboService.updateComboToFail(gameId = game.id)
-            GameState.CANCEL -> comboService.updateComboToPass(gameId = game.id)
+            GameState.CANCEL -> comboService.updateComboToPass(gameId = game.id, LocalDateTime.now())
             else -> { }
         }
         comboRankService.process(game = game)

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameHandler.kt
@@ -27,6 +27,10 @@ class GameHandler(
 
         gameService.complete(gameId)
 
+        gameEndEventJobRepository.findByGameId(gameId)?.let {
+            return
+        }
+
         val gameEndEventJob = GameEndEventJob(
             gameId = gameId,
             gameDate = gameDate,
@@ -65,6 +69,10 @@ class GameHandler(
 
         gameService.cancel(gameId)
         logInfo("Game is canceled: $gameId")
+
+        gameEndEventJobRepository.findByGameId(gameId)?.let {
+            return
+        }
 
         val gameEndEventJob = GameEndEventJob(
             gameId = gameId,

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
@@ -31,7 +31,7 @@ class GameScheduler(
             .filter { it.createdDateTime.isBefore(now.minusMinutes(10)) }
             .map { it.id }
 
-        processableJobIds.forEach { gameEndEventJobService.process(it!!) }
+        processableJobIds.forEach { gameEndEventJobService.process(it!!, now) }
     }
 
     @Scheduled(cron = "0 0/10 * * * ?")

--- a/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
@@ -81,7 +81,7 @@ class Game(
     }
 
     fun isAfterGameStart(dateTime: LocalDateTime): Boolean {
-        return LocalDateTime.of(startDate, startTime) >= dateTime
+        return LocalDateTime.of(startDate, startTime) < dateTime
     }
 
     fun cancel() {

--- a/src/main/kotlin/com/example/kbocombo/game/infra/GameEndEventJobRepository.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/infra/GameEndEventJobRepository.kt
@@ -2,6 +2,7 @@ package com.example.kbocombo.game.infra
 
 import com.example.kbocombo.game.domain.GameEndEventJob
 import org.springframework.data.repository.Repository
+import java.time.LocalDate
 
 interface GameEndEventJobRepository : Repository<GameEndEventJob, Long> {
 
@@ -10,4 +11,6 @@ interface GameEndEventJobRepository : Repository<GameEndEventJob, Long> {
     fun findAllByProcessed(processed: Boolean): List<GameEndEventJob>
 
     fun findById(id: Long): GameEndEventJob
+
+    fun findByGameId(gameId: Long): GameEndEventJob?
 }

--- a/src/test/kotlin/com/example/kbocombo/KboComboApplicationTests.kt
+++ b/src/test/kotlin/com/example/kbocombo/KboComboApplicationTests.kt
@@ -1,9 +1,9 @@
 package com.example.kbocombo
 
+import com.example.kbocombo.annotation.IntegrationTest
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
 
-@SpringBootTest
+@IntegrationTest
 class KboComboApplicationTests {
 
     @Test

--- a/src/test/kotlin/com/example/kbocombo/annotation/IntegrationTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/annotation/IntegrationTest.kt
@@ -1,0 +1,16 @@
+package com.example.kbocombo.annotation
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.core.annotation.AliasFor
+import org.springframework.transaction.annotation.Transactional
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.CLASS)
+@Transactional
+@SpringBootTest
+annotation class IntegrationTest(
+
+    @get:AliasFor(annotation = SpringBootTest::class, attribute = "classes")
+    val classes: Array<KClass<*>> = []
+)
+

--- a/src/test/kotlin/com/example/kbocombo/combo/application/ComboRankQueryServiceTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/combo/application/ComboRankQueryServiceTest.kt
@@ -1,0 +1,95 @@
+package com.example.kbocombo.combo.application
+
+import com.example.kbocombo.annotation.IntegrationTest
+import com.example.kbocombo.combo.domain.ComboRank
+import com.example.kbocombo.combo.infra.ComboRankRepository
+import com.example.kbocombo.game.domain.vo.GameType
+import com.example.kbocombo.member.domain.Member
+import com.example.kbocombo.member.domain.vo.SocialProvider
+import com.example.kbocombo.member.infra.MemberRepository
+import com.example.kbocombo.utils.fixture
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.navercorp.fixturemonkey.kotlin.giveMeKotlinBuilder
+import io.kotest.core.spec.style.ExpectSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+@IntegrationTest
+class ComboRankQueryServiceTest(
+    private val comboRankQueryService: ComboRankQueryService,
+    private val comboRankRepository: ComboRankRepository,
+    private val memberRepository: MemberRepository
+) : ExpectSpec({
+
+    val comboYear = 2025
+
+    context("콤보 랭크 기록") {
+        expect("최초로 생성되는 엔티티에는 기록이 초기화 되어 있다.") {
+            val member = memberRepository.save(getMember().sample())
+            val comboRank =
+                ComboRank.init(memberId = member.id, years = comboYear, gameType = GameType.REGULAR_SEASON)
+
+            val savedComboRank = comboRankRepository.save(comboRank)
+
+            savedComboRank.memberId shouldBe member.id
+            savedComboRank.currentRecord shouldBe 0
+            savedComboRank.totalCount shouldBe 0
+            savedComboRank.successCount shouldBe 0
+            savedComboRank.failCount shouldBe 0
+            savedComboRank.passCount shouldBe 0
+            savedComboRank.firstSuccessDate shouldBe null
+            savedComboRank.lastSuccessDate shouldBe null
+        }
+    }
+
+    context("콤보 랭크 통계 조회") {
+        expect("회원의 콤보 랭크 내역을 연도와 게임 타입으로 나눠 반환한다.") {
+            val member = memberRepository.save(getMember().sample())
+            val comboRankA =
+                ComboRank.init(memberId = member.id, years = comboYear, gameType = GameType.PRE_SEASON)
+            val comboRankB =
+                ComboRank.init(memberId = member.id, years = comboYear, gameType = GameType.REGULAR_SEASON)
+            val comboRankC =
+                ComboRank.init(memberId = member.id, years = comboYear, gameType = GameType.POST_SEASON)
+            val comboRankD =
+                ComboRank.init(memberId = member.id, years = 2024, gameType = GameType.REGULAR_SEASON)
+            comboRankRepository.saveAll(listOf(comboRankA, comboRankB, comboRankC, comboRankD))
+
+            val memberComboRanks = comboRankQueryService.getMemberComboRank(memberId = member.id)
+
+            println(ObjectMapper().writeValueAsString(memberComboRanks))
+        }
+
+        expect("상위 N명을 조회하고 동점자 처리를 통해 순위를 결정한다.") {
+            val memberA = memberRepository.save(getMember().sample())
+            val memberB = memberRepository.save(getMember().sample())
+            val memberC = memberRepository.save(getMember().sample())
+            val comboRankA =
+                ComboRank.init(memberId = memberA.id, years = comboYear, gameType = GameType.REGULAR_SEASON)
+            val comboRankB =
+                ComboRank.init(memberId = memberB.id, years = comboYear, gameType = GameType.REGULAR_SEASON)
+            val comboRankC =
+                ComboRank.init(memberId = memberC.id, years = comboYear, gameType = GameType.REGULAR_SEASON)
+            comboRankB.recordComboSuccess(gameDate = LocalDate.now())
+            comboRankC.recordComboSuccess(gameDate = LocalDate.now())
+            comboRankRepository.saveAll(listOf(comboRankA, comboRankB, comboRankC)) // memberB, memberC 동률
+
+            val rankStatistic = comboRankQueryService.getComboRankStatistic(
+                year = comboYear,
+                count = 3,
+                gameType = GameType.REGULAR_SEASON
+            )
+
+            rankStatistic.comboRankResponse.size shouldBe 3
+            rankStatistic.comboRankResponse[0].rank shouldBe 1
+            rankStatistic.comboRankResponse[1].rank shouldBe 1
+            rankStatistic.comboRankResponse[2].rank shouldBe 3
+            rankStatistic.gameType shouldBe GameType.REGULAR_SEASON.name
+        }
+    }
+})
+
+private fun getMember() =
+    fixture.giveMeKotlinBuilder<Member>()
+        .setExp(Member::id, 0L)
+        .setExp(Member::socialProvider, SocialProvider.KAKAO)

--- a/src/test/kotlin/com/example/kbocombo/combo/application/ComboServiceTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/combo/application/ComboServiceTest.kt
@@ -1,5 +1,6 @@
 package com.example.kbocombo.combo.application
 
+import com.example.kbocombo.annotation.IntegrationTest
 import com.example.kbocombo.combo.domain.Combo
 import com.example.kbocombo.combo.domain.vo.ComboStatus
 import com.example.kbocombo.combo.infra.ComboRepository
@@ -18,10 +19,9 @@ import com.navercorp.fixturemonkey.kotlin.giveMeKotlinBuilder
 import io.kotest.assertions.throwables.shouldThrowWithMessage
 import io.kotest.core.spec.style.ExpectSpec
 import io.kotest.matchers.shouldBe
-import org.springframework.boot.test.context.SpringBootTest
 import java.time.LocalDateTime
 
-@SpringBootTest
+@IntegrationTest
 class ComboServiceTest(
     private val memberRepository: MemberRepository,
     private val gameRepository: GameRepository,

--- a/src/test/kotlin/com/example/kbocombo/combo/infra/ComboRankQueryRepositoryTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/combo/infra/ComboRankQueryRepositoryTest.kt
@@ -1,0 +1,70 @@
+package com.example.kbocombo.combo.infra
+
+import com.example.kbocombo.annotation.IntegrationTest
+import com.example.kbocombo.combo.domain.ComboRank
+import com.example.kbocombo.game.domain.vo.GameType
+import com.example.kbocombo.member.domain.Member
+import com.example.kbocombo.member.domain.vo.SocialProvider
+import com.example.kbocombo.member.infra.MemberRepository
+import com.example.kbocombo.utils.fixture
+import com.navercorp.fixturemonkey.kotlin.giveMeKotlinBuilder
+import io.kotest.core.spec.style.ExpectSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+@IntegrationTest
+class ComboRankQueryRepositoryTest(
+    private val comboRankRepository: ComboRankRepository,
+    private val comboRankQueryRepository: ComboRankQueryRepository,
+    private val memberRepository: MemberRepository
+) : ExpectSpec({
+
+    context("콤보 랭크 상위 N명 조회") {
+        expect("상위 3명을 조회한다.") {
+            val memberA = memberRepository.save(getMember().sample())
+            val memberB = memberRepository.save(getMember().sample())
+            val memberC = memberRepository.save(getMember().sample())
+            val comboRankA = ComboRank.init(
+                memberId = memberA.id,
+                years = LocalDate.now().year,
+                gameType = GameType.REGULAR_SEASON
+            )
+            val comboRankB = ComboRank.init(
+                memberId = memberB.id,
+                years = LocalDate.now().year,
+                gameType = GameType.REGULAR_SEASON
+            )
+            val comboRankC = ComboRank.init(
+                memberId = memberC.id,
+                years = LocalDate.now().year,
+                gameType = GameType.REGULAR_SEASON
+            )
+            val comboRankD = ComboRank.init(
+                memberId = memberC.id,
+                years = LocalDate.now().year,
+                gameType = GameType.PRE_SEASON
+            )
+            comboRankB.recordComboSuccess(gameDate = LocalDate.now())
+            comboRankC.recordComboSuccess(gameDate = LocalDate.now())
+            comboRankC.recordComboSuccess(gameDate = LocalDate.now())
+            comboRankD.recordComboSuccess(gameDate = LocalDate.of(2025, 3, 2))
+            comboRankRepository.saveAll(listOf(comboRankA, comboRankB, comboRankC, comboRankD))
+
+            val findTopRanks = comboRankQueryRepository.findTopRanks(
+                year = LocalDate.now().year,
+                limit = 3,
+                gameType = GameType.REGULAR_SEASON
+            )
+
+            findTopRanks.size shouldBe 3
+            findTopRanks[0].memberId shouldBe memberC.id
+            findTopRanks[1].memberId shouldBe memberB.id
+            findTopRanks[2].memberId shouldBe memberA.id
+        }
+    }
+})
+
+private fun getMember() =
+    fixture.giveMeKotlinBuilder<Member>()
+        .setExp(Member::id, 0L)
+        .setExp(Member::socialProvider, SocialProvider.KAKAO)

--- a/src/test/kotlin/com/example/kbocombo/crawler/game/application/GameSyncServiceTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/crawler/game/application/GameSyncServiceTest.kt
@@ -1,16 +1,16 @@
 package com.example.kbocombo.crawler.game.application
 
+import com.example.kbocombo.annotation.IntegrationTest
 import io.kotest.core.annotation.Ignored
 import io.kotest.core.spec.style.FunSpec
 import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores
-import org.springframework.boot.test.context.SpringBootTest
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Ignored
 @DisplayNameGeneration(ReplaceUnderscores::class)
-@SpringBootTest
+@IntegrationTest
 class GameSyncServiceTest(
     private val sut: GameSyncService
 ) : FunSpec({

--- a/src/test/kotlin/com/example/kbocombo/crawler/player/infra/KboPlayerListPageCrawlerTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/crawler/player/infra/KboPlayerListPageCrawlerTest.kt
@@ -1,15 +1,15 @@
 package com.example.kbocombo.crawler.player.infra
 
+import com.example.kbocombo.annotation.IntegrationTest
 import com.example.kbocombo.player.vo.WebId
 import io.kotest.core.annotation.Ignored
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
-import org.springframework.boot.test.context.SpringBootTest
 
 @Ignored
-@SpringBootTest
-class KboPlayerListPageCrawlerTest (
+@IntegrationTest
+class KboPlayerListPageCrawlerTest(
     private val sut: KboPlayerListPageCrawler
 ) : FunSpec({
 

--- a/src/test/kotlin/com/example/kbocombo/member/application/MemberServiceTest.kt
+++ b/src/test/kotlin/com/example/kbocombo/member/application/MemberServiceTest.kt
@@ -1,4 +1,6 @@
-package com.example.kbocombo.member.application 
+package com.example.kbocombo.member.application
+
+import com.example.kbocombo.annotation.IntegrationTest
 import com.example.kbocombo.exception.type.BadRequestException
 import com.example.kbocombo.member.domain.Member
 import com.example.kbocombo.member.domain.vo.SocialProvider
@@ -7,11 +9,8 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.ExpectSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.transaction.annotation.Transactional
 
-@SpringBootTest
-@Transactional
+@IntegrationTest
 class MemberServiceTest(
     private val memberRepository: MemberRepository,
     private val memberService: MemberService
@@ -35,18 +34,22 @@ class MemberServiceTest(
         }
 
         expect("중복된 닉네임이면 예외가 발생한다.") {
-            val duplicateNameMember = memberRepository.save(Member(
-                email = "kbocombo@example.com",
-                nickname = "duplicateNickname",
-                socialProvider = SocialProvider.KAKAO,
-                socialId = "456"
-            ))
-            val savedMember = memberRepository.save(Member(
-                email = "kbocombo@example.co.kr",
-                nickname = "originMember",
-                socialProvider = SocialProvider.KAKAO,
-                socialId = "123"
-            ))
+            val duplicateNameMember = memberRepository.save(
+                Member(
+                    email = "kbocombo@example.com",
+                    nickname = "duplicateNickname",
+                    socialProvider = SocialProvider.KAKAO,
+                    socialId = "456"
+                )
+            )
+            val savedMember = memberRepository.save(
+                Member(
+                    email = "kbocombo@example.co.kr",
+                    nickname = "originMember",
+                    socialProvider = SocialProvider.KAKAO,
+                    socialId = "123"
+                )
+            )
 
             val updateNickname = duplicateNameMember.nickname
 


### PR DESCRIPTION
1. 게임이 CANCEL일때 PASS로 처리해야하는데 COMPLETE일때 PASS하고 있었습니다.

2. 오늘과 같이 13:00 게임이 미리 11:00에 우천취소 확정됐을때, 콤보를 PASS처리하거나 랭킹을 계산하면 문제가 생깁니다. 
유저가 다시 취소하고 다른 콤보를 선택할 기회가 있으니까요. 그래서 게임 시작시간 이후에 처리하도록 했습니다.