### PR TITLE
게임 취소일시 콤보를 PASS 처리못하던 문제 수정

### DIFF
--- a/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
@@ -89,8 +89,8 @@ class ComboService(
     @Transactional
     fun updateComboToPass(gameId: Long) {
         val game = gameRepository.getById(gameId)
-        if (game.isCompleted().not()) {
-            throw IllegalArgumentException("게임이 종료되지 않은 경우, 콤보 패스 처리를 할 수 없습니다.")
+        if (game.isCancelled().not()) {
+            throw IllegalArgumentException("게임이 취소되지 않은 경우, 콤보 패스 처리를 할 수 없습니다.")
         }
 
         val combos = comboRepository.findAllByGame(game = game)

--- a/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
@@ -89,11 +89,6 @@ class ComboService(
     @Transactional
     fun updateComboToPass(gameId: Long, now: LocalDateTime) {
         val game = gameRepository.getById(gameId)
-
-        if (game.isAfterGameStart(now).not()) {
-            return
-        }
-
         if (game.isCancelled().not()) {
             throw IllegalArgumentException("게임이 취소되지 않은 경우, 콤보 패스 처리를 할 수 없습니다.")
         }

--- a/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
+++ b/src/main/kotlin/com/example/kbocombo/combo/application/ComboService.kt
@@ -87,8 +87,13 @@ class ComboService(
     }
 
     @Transactional
-    fun updateComboToPass(gameId: Long) {
+    fun updateComboToPass(gameId: Long, now: LocalDateTime) {
         val game = gameRepository.getById(gameId)
+
+        if (game.isAfterGameStart(now).not()) {
+            return
+        }
+
         if (game.isCancelled().not()) {
             throw IllegalArgumentException("게임이 취소되지 않은 경우, 콤보 패스 처리를 할 수 없습니다.")
         }

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
@@ -19,11 +19,11 @@ class GameEndEventJobService(
 ) {
     
     @Transactional
-    fun process(gameEndEventJobId: Long) {
+    fun process(gameEndEventJobId: Long, now: LocalDateTime) {
         val gameEndEventJob = gameEndEventJobRepository.findById(gameEndEventJobId)
         val game = gameRepository.getById(gameEndEventJob.gameId)
 
-        if (game.isAfterGameStart(LocalDateTime.now()).not()) {
+        if (game.isAfterGameStart(now).not()) {
             return
         }
 

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
@@ -23,6 +23,10 @@ class GameEndEventJobService(
         val gameEndEventJob = gameEndEventJobRepository.findById(gameEndEventJobId)
         val game = gameRepository.getById(gameEndEventJob.gameId)
 
+        if (game.isAfterGameStart(LocalDateTime.now()).not()) {
+            return
+        }
+
         when (game.gameState) {
             GameState.COMPLETED -> comboService.updateComboToFail(gameId = game.id)
             GameState.CANCEL -> comboService.updateComboToPass(gameId = game.id, LocalDateTime.now())

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameEndEventJobService.kt
@@ -8,6 +8,7 @@ import com.example.kbocombo.game.infra.GameRepository
 import com.example.kbocombo.game.infra.getById
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class GameEndEventJobService(
@@ -24,7 +25,7 @@ class GameEndEventJobService(
 
         when (game.gameState) {
             GameState.COMPLETED -> comboService.updateComboToFail(gameId = game.id)
-            GameState.CANCEL -> comboService.updateComboToPass(gameId = game.id)
+            GameState.CANCEL -> comboService.updateComboToPass(gameId = game.id, LocalDateTime.now())
             else -> { }
         }
         comboRankService.process(game = game)

--- a/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/application/GameScheduler.kt
@@ -31,7 +31,7 @@ class GameScheduler(
             .filter { it.createdDateTime.isBefore(now.minusMinutes(10)) }
             .map { it.id }
 
-        processableJobIds.forEach { gameEndEventJobService.process(it!!) }
+        processableJobIds.forEach { gameEndEventJobService.process(it!!, now) }
     }
 
     @Scheduled(cron = "0 0/10 * * * ?")

--- a/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
+++ b/src/main/kotlin/com/example/kbocombo/game/domain/Game.kt
@@ -81,7 +81,7 @@ class Game(
     }
 
     fun isAfterGameStart(dateTime: LocalDateTime): Boolean {
-        return LocalDateTime.of(startDate, startTime) >= dateTime
+        return LocalDateTime.of(startDate, startTime) < dateTime
     }
 
     fun cancel() {


### PR DESCRIPTION
1. 게임이 CANCEL일때 PASS로 처리해야하는데 COMPLETE일때 PASS하고 있었습니다.

2. 오늘과 같이 13:00 게임이 미리 11:00에 우천취소 확정됐을때, 게임 시작시간 이전에 콤보를 PASS처리하거나 랭킹을 계산하면 문제가 생깁니다. 유저가 다시 취소하고 다른 콤보를 선택할 기회가 있으니까요. 그래서 게임 시작시간 이후에 처리하도록 했습니다.